### PR TITLE
Makefile indentation fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ release:
 	./gradlew :library:assembleRelease
 
 publish:
-    export IS_LOCAL_DEVELOPMENT=false; ./gradlew :library:uploadArchives
+	export IS_LOCAL_DEVELOPMENT=false; ./gradlew :library:uploadArchives
 
 publish-local:
-    # This publishes to ~/.m2/repository/com/mapbox/mapboxsdk
-    export IS_LOCAL_DEVELOPMENT=true; ./gradlew :library:uploadArchives
+	# This publishes to ~/.m2/repository/com/mapbox/mapboxsdk
+	export IS_LOCAL_DEVELOPMENT=true; ./gradlew :library:uploadArchives


### PR DESCRIPTION
Makefile rules have to be indented with a TAB instead of 4 spaces.