### PR TITLE
MoveGestureDetector

### DIFF
--- a/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
+++ b/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
@@ -31,7 +31,8 @@ public class AndroidGesturesManager {
     GESTURE_TYPE_DOWN,
     GESTURE_TYPE_DOUBLE_TAP,
     GESTURE_TYPE_DOUBLE_TAP_EVENT,
-    GESTURE_TYPE_SINGLE_TAP_CONFIRMED
+    GESTURE_TYPE_SINGLE_TAP_CONFIRMED,
+    GESTURE_TYPE_MOVE
   })
   public @interface GestureType {
   }
@@ -49,6 +50,7 @@ public class AndroidGesturesManager {
   public static final int GESTURE_TYPE_DOUBLE_TAP = 10;
   public static final int GESTURE_TYPE_DOUBLE_TAP_EVENT = 11;
   public static final int GESTURE_TYPE_SINGLE_TAP_CONFIRMED = 12;
+  public static final int GESTURE_TYPE_MOVE = 13;
 
   private final List<Set<Integer>> mutuallyExclusiveGestures = new ArrayList<>();
   private final List<BaseGesture> detectors = new ArrayList<>();
@@ -58,6 +60,7 @@ public class AndroidGesturesManager {
   private final RotateGestureDetector rotateGestureDetector;
   private final ShoveGestureDetector shoveGestureDetector;
   private final MultiFingerTapGestureDetector multiFingerTapGestureDetector;
+  private final MoveGestureDetector moveGestureDetector;
 
   /**
    * Creates a new instance of the {@link AndroidGesturesManager}.
@@ -105,12 +108,14 @@ public class AndroidGesturesManager {
     rotateGestureDetector = new RotateGestureDetector(context, this);
     shoveGestureDetector = new ShoveGestureDetector(context, this);
     multiFingerTapGestureDetector = new MultiFingerTapGestureDetector(context, this);
+    moveGestureDetector = new MoveGestureDetector(context, this);
 
     detectors.add(standardGestureDetector);
     detectors.add(standardScaleGestureDetector);
     detectors.add(rotateGestureDetector);
     detectors.add(shoveGestureDetector);
     detectors.add(multiFingerTapGestureDetector);
+    detectors.add(moveGestureDetector);
   }
 
   /**
@@ -191,14 +196,12 @@ public class AndroidGesturesManager {
     shoveGestureDetector.setListener(listener);
   }
 
-
   /**
    * Removes a listener for shove gestures.
    */
   public void removeShoveGestureListener() {
     shoveGestureDetector.removeListener();
   }
-
 
   /**
    * Sets a listener for multi finger tap gestures.
@@ -209,12 +212,35 @@ public class AndroidGesturesManager {
     multiFingerTapGestureDetector.setListener(listener);
   }
 
-
   /**
    * Removes a listener for multi finger tap gestures.
    */
   public void removeMultiFingerTapGestureListener() {
     multiFingerTapGestureDetector.removeListener();
+  }
+
+  /**
+   * Sets a listener for move gestures.
+   * <p>
+   * {@link MoveGestureDetector} serves similar purpose to
+   * {@link com.mapbox.android.gestures.StandardGestureDetector.StandardOnGestureListener
+   * #onScroll(MotionEvent, MotionEvent, float, float)}, however, it's a {@link ProgressiveGesture} that
+   * introduces {@link MoveGestureDetector.OnMoveGestureListener#onMoveBegin(MoveGestureDetector)},
+   * {@link MoveGestureDetector.OnMoveGestureListener#onMoveEnd(MoveGestureDetector)},
+   * threshold with {@link MoveGestureDetector#setMoveThreshold(float)} and multi finger support thanks to
+   * {@link MoveDistancesObject}.
+   *
+   * @param listener your gestures listener
+   */
+  public void setMoveGestureListener(MoveGestureDetector.OnMoveGestureListener listener) {
+    moveGestureDetector.setListener(listener);
+  }
+
+  /**
+   * Removes a listener for move gestures.
+   */
+  public void removeMoveGestureListener() {
+    moveGestureDetector.removeListener();
   }
 
   /**
@@ -272,6 +298,15 @@ public class AndroidGesturesManager {
   }
 
   /**
+   * Get move gesture detector.
+   *
+   * @return gesture detector
+   */
+  public MoveGestureDetector getMoveGestureDetector() {
+    return moveGestureDetector;
+  }
+
+  /**
    * Sets a number of sets containing mutually exclusive gestures.
    *
    * @param exclusiveGestures a number of sets of {@link GestureType}s that <b>should not</b> be invoked at the same.
@@ -303,6 +338,12 @@ public class AndroidGesturesManager {
     this.mutuallyExclusiveGestures.addAll(exclusiveGestures);
   }
 
+  /**
+   * Returns a list of sets containing mutually exclusive gestures.
+   *
+   * @return mutually exclusive gestures
+   * @see #setMutuallyExclusiveGestures(List)
+   */
   public List<Set<Integer>> getMutuallyExclusiveGestures() {
     return mutuallyExclusiveGestures;
   }

--- a/library/src/main/java/com/mapbox/android/gestures/Constants.java
+++ b/library/src/main/java/com/mapbox/android/gestures/Constants.java
@@ -13,4 +13,7 @@ final class Constants {
   // Shove
   static final float DEFAULT_SHOVE_MAX_ANGLE = 20f;
   static final float DEFAULT_SHOVE_PIXEL_THRESHOLD = 100f;
+
+  // Move
+  static final float DEFAULT_MOVE_THRESHOLD = 0f;
 }

--- a/library/src/main/java/com/mapbox/android/gestures/MoveDistancesObject.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveDistancesObject.java
@@ -1,0 +1,118 @@
+package com.mapbox.android.gestures;
+
+/**
+ * Class that holds initial, previous and current X and Y on-screen coordinates for active pointers.
+ */
+public final class MoveDistancesObject {
+  private final float initialX;
+  private final float initialY;
+
+  private float prevX;
+  private float prevY;
+  private float currX;
+  private float currY;
+
+  private float distanceXSinceLast;
+  private float distanceYSinceLast;
+  private float distanceXSinceStart;
+  private float distanceYSinceStart;
+
+  MoveDistancesObject(float initialX, float initialY) {
+    this.initialX = initialX;
+    this.initialY = initialY;
+  }
+
+  void addNewPosition(float x, float y) {
+    prevX = currX;
+    prevY = currY;
+
+    currX = x;
+    currY = y;
+
+    distanceXSinceLast = prevX - currX;
+    distanceYSinceLast = prevY - currY;
+
+    distanceXSinceStart = initialX - currX;
+    distanceYSinceStart = initialY - currY;
+  }
+
+  /**
+   * Get X coordinate of this pointer when it was first register.
+   * @return X coordinate
+   */
+  public float getInitialX() {
+    return initialX;
+  }
+
+  /**
+   * Get Y coordinate of this pointer when it was first register.
+   * @return Y coordinate
+   */
+  public float getInitialY() {
+    return initialY;
+  }
+
+  /**
+   * Get previous X coordinate of this pointer.
+   * @return X coordinate
+   */
+  public float getPreviousX() {
+    return prevX;
+  }
+
+  /**
+   * Get previous Y coordinate of this pointer.
+   * @return Y coordinate
+   */
+  public float getPreviousY() {
+    return prevY;
+  }
+
+  /**
+   * Get current X coordinate of this pointer.
+   * @return X coordinate
+   */
+  public float getCurrentX() {
+    return currX;
+  }
+
+  /**
+   * Get current Y coordinate of this pointer.
+   * @return Y coordinate
+   */
+  public float getCurrentY() {
+    return currY;
+  }
+
+  /**
+   * Get X distance covered by this pointer since previous position.
+   * @return X distance
+   */
+  public float getDistanceXSinceLast() {
+    return distanceXSinceLast;
+  }
+
+  /**
+   * Get Y distance covered by this pointer since previous position.
+   * @return Y distance
+   */
+  public float getDistanceYSinceLast() {
+    return distanceYSinceLast;
+  }
+
+  /**
+   * Get X distance covered by this pointer since start position.
+   * @return X distance
+   */
+  public float getDistanceXSinceStart() {
+    return distanceXSinceStart;
+  }
+
+  /**
+   * Get Y distance covered by this pointer since start position.
+   * @return Y distance
+   */
+  public float getDistanceYSinceStart() {
+    return distanceYSinceStart;
+  }
+}

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -1,0 +1,230 @@
+package com.mapbox.android.gestures;
+
+import android.content.Context;
+import android.graphics.PointF;
+import android.support.annotation.NonNull;
+import android.view.MotionEvent;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.mapbox.android.gestures.AndroidGesturesManager.GESTURE_TYPE_MOVE;
+
+/**
+ * Gesture detector handling move gesture.
+ * <p>
+ * {@link MoveGestureDetector} serves similar purpose to
+ * {@link com.mapbox.android.gestures.StandardGestureDetector.StandardOnGestureListener
+ * #onScroll(MotionEvent, MotionEvent, float, float)}, however, it's a {@link ProgressiveGesture} that
+ * introduces {@link OnMoveGestureListener#onMoveBegin(MoveGestureDetector)},
+ * {@link OnMoveGestureListener#onMoveEnd(MoveGestureDetector)},
+ * threshold with {@link MoveGestureDetector#setMoveThreshold(float)} and multi finger support thanks to
+ * {@link MoveDistancesObject}.
+ */
+public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.OnMoveGestureListener> {
+  private static final int MOVE_REQUIRED_POINTERS_COUNT = 1;
+  private static final Set<Integer> handledTypes = new HashSet<>();
+  private PointF previousFocalPoint;
+  private boolean resetFocal;
+
+  static {
+    handledTypes.add(GESTURE_TYPE_MOVE);
+  }
+
+  private float moveThreshold = Constants.DEFAULT_MOVE_THRESHOLD;
+  private final Map<Integer, MoveDistancesObject> moveDistancesObjectMap = new HashMap<>();
+
+  protected MoveGestureDetector(Context context, AndroidGesturesManager gesturesManager) {
+    super(context, gesturesManager);
+  }
+
+  @NonNull
+  @Override
+  protected Set<Integer> provideHandledTypes() {
+    return handledTypes;
+  }
+
+  public interface OnMoveGestureListener {
+    /**
+     * Indicates that the move gesture started.
+     *
+     * @param detector this detector
+     * @return true if you want to receive subsequent {@link #onMove(MoveGestureDetector, float, float)} callbacks,
+     * false if you want to ignore this gesture.
+     */
+    boolean onMoveBegin(MoveGestureDetector detector);
+
+    /**
+     * Called for every move change during the gesture.
+     *
+     * @param detector this detector
+     * @return true if the gesture was handled, false otherwise
+     */
+    boolean onMove(MoveGestureDetector detector, float distanceX, float distanceY);
+
+    /**
+     * Indicates that the move gesture ended.
+     *
+     * @param detector this detector
+     */
+    void onMoveEnd(MoveGestureDetector detector);
+  }
+
+  public static class SimpleOnMoveGestureListener implements OnMoveGestureListener {
+
+    @Override
+    public boolean onMoveBegin(MoveGestureDetector detector) {
+      return true;
+    }
+
+    @Override
+    public boolean onMove(MoveGestureDetector detector, float distanceX, float distanceY) {
+      return false;
+    }
+
+    @Override
+    public void onMoveEnd(MoveGestureDetector detector) {
+      // No implementation
+    }
+  }
+
+  @Override
+  protected boolean analyzeEvent(MotionEvent motionEvent) {
+    switch (motionEvent.getActionMasked()) {
+      case MotionEvent.ACTION_DOWN:
+      case MotionEvent.ACTION_POINTER_DOWN:
+        resetFocal = true; //recalculating focal point
+
+        float x = motionEvent.getX(motionEvent.getActionIndex());
+        float y = motionEvent.getY(motionEvent.getActionIndex());
+        moveDistancesObjectMap.put(
+          motionEvent.getPointerId(motionEvent.getActionIndex()),
+          new MoveDistancesObject(x, y)
+        );
+        break;
+
+      case MotionEvent.ACTION_UP:
+      case MotionEvent.ACTION_POINTER_UP:
+        resetFocal = true; //recalculating focal point
+
+        moveDistancesObjectMap.remove(motionEvent.getPointerId(motionEvent.getActionIndex()));
+        break;
+
+      default:
+        break;
+    }
+
+    return super.analyzeEvent(motionEvent);
+  }
+
+  @Override
+  protected boolean analyzeMovement() {
+    super.analyzeMovement();
+    updateMoveDistancesObjects();
+
+    if (isInProgress()) {
+      PointF currentFocalPoint = getFocalPoint();
+      float distanceX = previousFocalPoint.x - currentFocalPoint.x;
+      float distanceY = previousFocalPoint.y - currentFocalPoint.y;
+      previousFocalPoint = currentFocalPoint;
+      if (resetFocal) {
+        resetFocal = false;
+        return listener.onMove(this, 0, 0);
+      }
+      return listener.onMove(this, distanceX, distanceY);
+    } else if (canExecute(GESTURE_TYPE_MOVE)) {
+      if (listener.onMoveBegin(this)) {
+        gestureStarted();
+        previousFocalPoint = getFocalPoint();
+        resetFocal = false;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void updateMoveDistancesObjects() {
+    for (int pointerId : pointerIdList) {
+      moveDistancesObjectMap.get(pointerId).addNewPosition(
+        getCurrentEvent().getX(getCurrentEvent().findPointerIndex(pointerId)),
+        getCurrentEvent().getY(getCurrentEvent().findPointerIndex(pointerId))
+      );
+    }
+  }
+
+  private boolean checkAnyMoveAboveThreshold() {
+    for (MoveDistancesObject moveDistancesObject : moveDistancesObjectMap.values()) {
+      if (Math.abs(moveDistancesObject.getDistanceXSinceStart()) > moveThreshold
+        || Math.abs(moveDistancesObject.getDistanceYSinceStart()) > moveThreshold) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  protected boolean canExecute(int invokedGestureType) {
+    return super.canExecute(invokedGestureType) && checkAnyMoveAboveThreshold();
+  }
+
+  @Override
+  protected void reset() {
+    super.reset();
+    moveDistancesObjectMap.clear();
+  }
+
+  @Override
+  protected int getRequiredPointersCount() {
+    return MOVE_REQUIRED_POINTERS_COUNT;
+  }
+
+  /**
+   * Get the delta pixel threshold required to qualify it as a move gesture.
+   *
+   * @return delta pixel threshold
+   */
+  public float getMoveThreshold() {
+    return moveThreshold;
+  }
+
+  /**
+   * Set the delta pixel threshold required to qualify it as a move gesture.
+   *
+   * @param moveThreshold delta pixel threshold
+   */
+  public void setMoveThreshold(float moveThreshold) {
+    this.moveThreshold = moveThreshold;
+  }
+
+  /**
+   * Get the default delta pixel threshold required to qualify it as a move gesture.
+   *
+   * @return delta pixel threshold
+   * @see Constants#DEFAULT_MOVE_THRESHOLD
+   */
+  public float getDefaultMoveThreshold() {
+    return Constants.DEFAULT_MOVE_THRESHOLD;
+  }
+
+  /**
+   * Returns {@link MoveDistancesObject} referencing the pointer held under passed index.
+   * <p>
+   * Pointers are sorted by the time they were placed on the screen until lifted up.
+   * This means that index 0 will reflect the oldest added, still active pointer
+   * and index ({@link #getPointersCount()} - 1) will reflect the latest added, still active pointer.
+   * <p>
+   *
+   * @param pointerIndex pointer's index
+   * @return distances object of the referenced pointer
+   */
+  public MoveDistancesObject getMoveObject(int pointerIndex) {
+    if (isInProgress()) {
+      if (pointerIndex >= 0 && pointerIndex < getPointersCount()) {
+        return moveDistancesObjectMap.get(pointerIdList.get(pointerIndex));
+      }
+    }
+    return null;
+  }
+}

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
@@ -31,6 +31,8 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
    */
   private static final float PRESSURE_THRESHOLD = 0.67f;
 
+  private static final int DEFAULT_REQUIRED_FINGERS_COUNT = 2;
+
   private final float edgeSlop;
 
   private float spanThreshold = Constants.DEFAULT_MULTI_FINGER_SPAN_THRESHOLD;
@@ -65,7 +67,7 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
         break;
 
       case MotionEvent.ACTION_MOVE:
-        if (pointerIdList.size() > 1 && checkPressure()) {
+        if (pointerIdList.size() >= getRequiredPointersCount() && checkPressure()) {
           calculateDistances();
           if (!isSloppyGesture(getCurrentEvent())) {
             focalPoint = Utils.determineFocalPoint(motionEvent);
@@ -98,6 +100,10 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
     return false;
   }
 
+  protected int getRequiredPointersCount() {
+    return DEFAULT_REQUIRED_FINGERS_COUNT;
+  }
+
   protected boolean analyzeMovement() {
     return false;
   }
@@ -111,7 +117,7 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
    * @param event motion event
    * @return true if we detect sloppy gesture, false otherwise
    */
-  private boolean isSloppyGesture(MotionEvent event) {
+  protected boolean isSloppyGesture(MotionEvent event) {
     // As orientation can change, query the metrics in touch down
     DisplayMetrics metrics = context.getResources().getDisplayMetrics();
     float rightSlopEdge = metrics.widthPixels - edgeSlop;
@@ -335,7 +341,7 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
   }
 
   private boolean verifyPointers(int firstPointerIndex, int secondPointerIndex) {
-    return firstPointerIndex >= 0 && secondPointerIndex >= 0
+    return firstPointerIndex != secondPointerIndex && firstPointerIndex >= 0 && secondPointerIndex >= 0
       && firstPointerIndex < getPointersCount() && secondPointerIndex < getPointersCount();
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -48,19 +48,19 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
       int action = motionEvent.getActionMasked();
       switch (action) {
         case MotionEvent.ACTION_DOWN:
+        case MotionEvent.ACTION_POINTER_DOWN:
           if (isVelocityAnimating() && stopOnPointerDown) {
             valueAnimator.cancel();
           }
-          break;
 
-        case MotionEvent.ACTION_POINTER_DOWN:
           if (velocityTracker != null) {
             velocityTracker.clear();
           }
           break;
 
+        case MotionEvent.ACTION_UP:
         case MotionEvent.ACTION_POINTER_UP:
-          if (pointerIdList.size() <= 1 && isInProgress) {
+          if (pointerIdList.size() < getRequiredPointersCount() && isInProgress) {
             gestureStopped();
             return true;
           }
@@ -89,7 +89,6 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
     if (velocityTracker == null) {
       velocityTracker = VelocityTracker.obtain();
     }
-    reset();
   }
 
   protected void gestureStopped() {

--- a/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
@@ -3,6 +3,7 @@ package com.mapbox.android.gestures;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
+import android.view.MotionEvent;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -100,9 +101,13 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
 
   @Override
   protected boolean canExecute(int invokedGestureType) {
-    return verifyAngle()
-      && Math.abs(deltaPixelsSinceStart) > pixelDeltaThreshold
+    return Math.abs(deltaPixelsSinceStart) > pixelDeltaThreshold
       && super.canExecute(invokedGestureType);
+  }
+
+  @Override
+  protected boolean isSloppyGesture(MotionEvent event) {
+    return super.isSloppyGesture(event) || !isAngleAcceptable();
   }
 
   @Override
@@ -117,7 +122,7 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
     deltaPixelsSinceStart = 0;
   }
 
-  private boolean verifyAngle() {
+  private boolean isAngleAcceptable() {
     MultiFingerDistancesObject distancesObject =
       pointersDistanceMap.get(new PointerDistancePair(pointerIdList.get(0), pointerIdList.get(1)));
 


### PR DESCRIPTION
Closes #3.

This PR adds `MoveGestureDetector` which behaves similarly to well known `onScroll()`, however, it's a `ProgressiveGesture` which allows better filtering and thresholds.

At this point, `MoveGestureDetector` doesn't provide its own animator or velocity values, those can be implemented with `onFling()` from `StandardGestureDetector`.