### PR TITLE
Enabled flag, interrupt gesture, animators cleanup

### DIFF
--- a/app/src/main/java/com/mapbox/android/gestures/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/android/gestures/testapp/MainActivity.java
@@ -250,7 +250,7 @@ public class MainActivity extends AppCompatActivity {
       }
 
       @Override
-      public void onMoveEnd(MoveGestureDetector detector) {
+      public void onMoveEnd(MoveGestureDetector detector, float velocityX, float velocityY) {
 
       }
     };

--- a/app/src/main/java/com/mapbox/android/gestures/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/android/gestures/testapp/MainActivity.java
@@ -183,16 +183,6 @@ public class MainActivity extends AppCompatActivity {
           rescaleIcon(detector.getScaleFactor());
           return true;
         }
-
-        @Override
-        public boolean scaleVelocityAnimator(StandardScaleGestureDetector detector, float velocityX, float velocityY,
-                                             float scaleVelocityAnimatorValue) {
-          if (!velocityEnabled) {
-            return false;
-          }
-          rescaleIcon(scaleVelocityAnimatorValue);
-          return true;
-        }
       });
 
     androidGesturesManager.setRotateGestureListener(new RotateGestureDetector.SimpleOnRotateGestureListener() {
@@ -200,16 +190,6 @@ public class MainActivity extends AppCompatActivity {
       public boolean onRotate(RotateGestureDetector detector, float rotationDegreesSinceLast,
                               float rotationDegreesSinceFirst) {
         icon.setRotation(icon.getRotation() - rotationDegreesSinceLast);
-        return true;
-      }
-
-      @Override
-      public boolean rotationVelocityAnimator(RotateGestureDetector detector, float velocityX, float velocityY,
-                                              float rotationVelocityAnimatorValue) {
-        if (!velocityEnabled) {
-          return false;
-        }
-        icon.setRotation(icon.getRotation() - rotationVelocityAnimatorValue * 5);
         return true;
       }
     });

--- a/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
+++ b/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
@@ -226,7 +226,7 @@ public class AndroidGesturesManager {
    * {@link com.mapbox.android.gestures.StandardGestureDetector.StandardOnGestureListener
    * #onScroll(MotionEvent, MotionEvent, float, float)}, however, it's a {@link ProgressiveGesture} that
    * introduces {@link MoveGestureDetector.OnMoveGestureListener#onMoveBegin(MoveGestureDetector)},
-   * {@link MoveGestureDetector.OnMoveGestureListener#onMoveEnd(MoveGestureDetector)},
+   * {@link MoveGestureDetector.OnMoveGestureListener#onMoveEnd(MoveGestureDetector, float, float)},
    * threshold with {@link MoveGestureDetector#setMoveThreshold(float)} and multi finger support thanks to
    * {@link MoveDistancesObject}.
    *

--- a/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
+++ b/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
@@ -103,19 +103,19 @@ public class AndroidGesturesManager {
   public AndroidGesturesManager(Context context, List<Set<Integer>> exclusiveGestures) {
     this.mutuallyExclusiveGestures.addAll(exclusiveGestures);
 
-    standardGestureDetector = new StandardGestureDetector(context, this);
-    standardScaleGestureDetector = new StandardScaleGestureDetector(context, this);
     rotateGestureDetector = new RotateGestureDetector(context, this);
+    standardScaleGestureDetector = new StandardScaleGestureDetector(context, this);
     shoveGestureDetector = new ShoveGestureDetector(context, this);
     multiFingerTapGestureDetector = new MultiFingerTapGestureDetector(context, this);
     moveGestureDetector = new MoveGestureDetector(context, this);
+    standardGestureDetector = new StandardGestureDetector(context, this);
 
-    detectors.add(standardGestureDetector);
-    detectors.add(standardScaleGestureDetector);
     detectors.add(rotateGestureDetector);
+    detectors.add(standardScaleGestureDetector);
     detectors.add(shoveGestureDetector);
     detectors.add(multiFingerTapGestureDetector);
     detectors.add(moveGestureDetector);
+    detectors.add(standardGestureDetector);
   }
 
   /**

--- a/library/src/main/java/com/mapbox/android/gestures/BaseGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/BaseGesture.java
@@ -18,6 +18,7 @@ public abstract class BaseGesture<L> {
   private MotionEvent currentEvent;
   private MotionEvent previousEvent;
   private long gestureDuration;
+  private boolean isEnabled = true;
 
   /**
    * Listener that will be called with gesture events/updates.
@@ -58,7 +59,7 @@ public abstract class BaseGesture<L> {
   protected abstract boolean analyzeEvent(MotionEvent motionEvent);
 
   protected boolean canExecute(@AndroidGesturesManager.GestureType int invokedGestureType) {
-    if (listener == null) {
+    if (listener == null || !isEnabled) {
       return false;
     }
 
@@ -118,5 +119,21 @@ public abstract class BaseGesture<L> {
    */
   public MotionEvent getPreviousEvent() {
     return previousEvent;
+  }
+
+  /**
+   * Check whether this detector accepts and analyzes motion events. Default is true.
+   * @return true if it analyzes, false otherwise
+   */
+  public boolean isEnabled() {
+    return isEnabled;
+  }
+
+  /**
+   * Set whether this detector should accept and analyze motion events. Default is true.
+   * @param enabled true if it should analyze, false otherwise
+   */
+  public void setEnabled(boolean enabled) {
+    isEnabled = enabled;
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/BaseGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/BaseGesture.java
@@ -69,7 +69,7 @@ public abstract class BaseGesture<L> {
             if (detector instanceof ProgressiveGesture) {
               ProgressiveGesture progressiveDetector = (ProgressiveGesture) detector;
               if (progressiveDetector.getHandledTypes().contains(gestureType)
-                && (progressiveDetector.isInProgress() || progressiveDetector.isVelocityAnimating())) {
+                && progressiveDetector.isInProgress()) {
                 return false;
               }
             }

--- a/library/src/main/java/com/mapbox/android/gestures/MoveDistancesObject.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveDistancesObject.java
@@ -17,12 +17,17 @@ public final class MoveDistancesObject {
   private float distanceXSinceStart;
   private float distanceYSinceStart;
 
-  MoveDistancesObject(float initialX, float initialY) {
+  public MoveDistancesObject(float initialX, float initialY) {
     this.initialX = initialX;
     this.initialY = initialY;
   }
 
-  void addNewPosition(float x, float y) {
+  /**
+   * Add a new position of this pointer and recalculate distances.
+   * @param x new X coordinate
+   * @param y new Y coordinate
+   */
+  public void addNewPosition(float x, float y) {
     prevX = currX;
     prevY = currY;
 

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -20,7 +20,7 @@ import static com.mapbox.android.gestures.AndroidGesturesManager.GESTURE_TYPE_MO
  * {@link com.mapbox.android.gestures.StandardGestureDetector.StandardOnGestureListener
  * #onScroll(MotionEvent, MotionEvent, float, float)}, however, it's a {@link ProgressiveGesture} that
  * introduces {@link OnMoveGestureListener#onMoveBegin(MoveGestureDetector)},
- * {@link OnMoveGestureListener#onMoveEnd(MoveGestureDetector)},
+ * {@link OnMoveGestureListener#onMoveEnd(MoveGestureDetector, float, float)},
  * threshold with {@link MoveGestureDetector#setMoveThreshold(float)} and multi finger support thanks to
  * {@link MoveDistancesObject}.
  */

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -98,7 +98,6 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
   protected boolean analyzeEvent(MotionEvent motionEvent) {
     switch (motionEvent.getActionMasked()) {
       case MotionEvent.ACTION_DOWN:
-        moveDistancesObjectMap.clear();
       case MotionEvent.ACTION_POINTER_DOWN:
         resetFocal = true; //recalculating focal point
 
@@ -118,6 +117,10 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
         resetFocal = true; //recalculating focal point
 
         moveDistancesObjectMap.remove(motionEvent.getPointerId(motionEvent.getActionIndex()));
+        break;
+
+      case MotionEvent.ACTION_CANCEL:
+        moveDistancesObjectMap.clear();
         break;
 
       default:

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -164,8 +164,8 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
 
   boolean checkAnyMoveAboveThreshold() {
     for (MoveDistancesObject moveDistancesObject : moveDistancesObjectMap.values()) {
-      if (Math.abs(moveDistancesObject.getDistanceXSinceStart()) > moveThreshold
-        || Math.abs(moveDistancesObject.getDistanceYSinceStart()) > moveThreshold) {
+      if (Math.abs(moveDistancesObject.getDistanceXSinceStart()) >= moveThreshold
+        || Math.abs(moveDistancesObject.getDistanceYSinceStart()) >= moveThreshold) {
         return true;
       }
     }

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -40,7 +40,7 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
   private float moveThreshold = Constants.DEFAULT_MOVE_THRESHOLD;
   private final Map<Integer, MoveDistancesObject> moveDistancesObjectMap = new HashMap<>();
 
-  protected MoveGestureDetector(Context context, AndroidGesturesManager gesturesManager) {
+  public MoveGestureDetector(Context context, AndroidGesturesManager gesturesManager) {
     super(context, gesturesManager);
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -71,9 +71,11 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
     /**
      * Indicates that the move gesture ended.
      *
-     * @param detector this detector
+     * @param velocityX velocityX of the gesture in the moment of lifting the fingers
+     * @param velocityY velocityY of the gesture in the moment of lifting the fingers
+     * @param detector  this detector
      */
-    void onMoveEnd(MoveGestureDetector detector);
+    void onMoveEnd(MoveGestureDetector detector, float velocityX, float velocityY);
   }
 
   public static class SimpleOnMoveGestureListener implements OnMoveGestureListener {
@@ -89,7 +91,7 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
     }
 
     @Override
-    public void onMoveEnd(MoveGestureDetector detector) {
+    public void onMoveEnd(MoveGestureDetector detector, float velocityX, float velocityY) {
       // No implementation
     }
   }
@@ -188,7 +190,7 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
   @Override
   protected void gestureStopped() {
     super.gestureStopped();
-    listener.onMoveEnd(this);
+    listener.onMoveEnd(this, velocityX, velocityY);
   }
 
   @Override

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -98,6 +98,7 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
   protected boolean analyzeEvent(MotionEvent motionEvent) {
     switch (motionEvent.getActionMasked()) {
       case MotionEvent.ACTION_DOWN:
+        moveDistancesObjectMap.clear();
       case MotionEvent.ACTION_POINTER_DOWN:
         resetFocal = true; //recalculating focal point
 
@@ -111,6 +112,8 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
 
       case MotionEvent.ACTION_UP:
         moveDistancesObjectMap.clear();
+        break;
+
       case MotionEvent.ACTION_POINTER_UP:
         resetFocal = true; //recalculating focal point
 

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -110,6 +110,7 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
         break;
 
       case MotionEvent.ACTION_UP:
+        moveDistancesObjectMap.clear();
       case MotionEvent.ACTION_POINTER_UP:
         resetFocal = true; //recalculating focal point
 
@@ -176,7 +177,6 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
   @Override
   protected void reset() {
     super.reset();
-    moveDistancesObjectMap.clear();
   }
 
   @Override

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
@@ -146,7 +146,6 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
   }
 
   protected void reset() {
-    pointersDistanceMap.clear();
   }
 
   private void calculateDistances() {

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
@@ -45,7 +45,7 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
   final HashMap<PointerDistancePair, MultiFingerDistancesObject> pointersDistanceMap = new HashMap<>();
   private PointF focalPoint = new PointF();
 
-  protected MultiFingerGesture(Context context, AndroidGesturesManager gesturesManager) {
+  public MultiFingerGesture(Context context, AndroidGesturesManager gesturesManager) {
     super(context, gesturesManager);
 
     ViewConfiguration config = ViewConfiguration.get(context);

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -37,7 +37,6 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
     if (interrupted) {
       interrupted = false;
       gestureStopped();
-      return false;
     }
 
     if (velocityTracker != null) {

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -33,6 +33,10 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
 
   @Override
   protected boolean analyzeEvent(MotionEvent motionEvent) {
+    if (!isEnabled()) {
+      gestureStopped();
+    }
+
     if (velocityTracker != null) {
       velocityTracker.addMovement(getCurrentEvent());
     }

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -19,6 +19,7 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
   private final Set<Integer> handledTypes = provideHandledTypes();
 
   private boolean isInProgress;
+  private boolean interrupted;
 
   VelocityTracker velocityTracker;
   float velocityX;
@@ -33,7 +34,8 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
 
   @Override
   protected boolean analyzeEvent(MotionEvent motionEvent) {
-    if (!isEnabled() && isInProgress) {
+    if ((!isEnabled() || interrupted) && isInProgress) {
+      interrupted = false;
       gestureStopped();
     }
 
@@ -110,5 +112,9 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
    */
   public boolean isInProgress() {
     return isInProgress;
+  }
+
+  public void interrupt() {
+    this.interrupted = true;
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -1,12 +1,10 @@
 package com.mapbox.android.gestures;
 
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
-import android.view.animation.Interpolator;
 
 import java.util.Set;
 
@@ -20,14 +18,11 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
 
   private final Set<Integer> handledTypes = provideHandledTypes();
 
-  private boolean stopOnPointerDown = true;
   private boolean isInProgress;
 
   VelocityTracker velocityTracker;
   float velocityX;
   float velocityY;
-  final ValueAnimator valueAnimator = new ValueAnimator();
-  private Interpolator interpolator;
 
   protected ProgressiveGesture(Context context, AndroidGesturesManager gesturesManager) {
     super(context, gesturesManager);
@@ -49,9 +44,6 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
       switch (action) {
         case MotionEvent.ACTION_DOWN:
         case MotionEvent.ACTION_POINTER_DOWN:
-          if (isVelocityAnimating() && stopOnPointerDown) {
-            valueAnimator.cancel();
-          }
 
           if (velocityTracker != null) {
             velocityTracker.clear();
@@ -103,10 +95,6 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
     reset();
   }
 
-  protected boolean isVelocityAnimating() {
-    return valueAnimator != null && valueAnimator.isStarted();
-  }
-
   Set<Integer> getHandledTypes() {
     return handledTypes;
   }
@@ -118,41 +106,5 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
    */
   public boolean isInProgress() {
     return isInProgress;
-  }
-
-  /**
-   * Check whether velocity animation should be stopped when new gesture starts. True by default.
-   *
-   * @return true if animation should stop on pointer down, false otherwise.
-   */
-  public boolean isStopOnPointerDown() {
-    return stopOnPointerDown;
-  }
-
-  /**
-   * Set whether velocity animation should be stopped when new gesture starts. True by default.
-   *
-   * @param stopOnPointerDown true if animation should stop on pointer down, false otherwise.
-   */
-  public void setStopOnPointerDown(boolean stopOnPointerDown) {
-    this.stopOnPointerDown = stopOnPointerDown;
-  }
-
-  /**
-   * Get current interpolator used for velocity animations.
-   *
-   * @return Currently used interpolator
-   */
-  public Interpolator getInterpolator() {
-    return interpolator;
-  }
-
-  /**
-   * Set new interpolator used for velocity animations.
-   *
-   * @param interpolator new interpolator
-   */
-  public void setInterpolator(Interpolator interpolator) {
-    this.interpolator = interpolator;
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -34,9 +34,10 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
 
   @Override
   protected boolean analyzeEvent(MotionEvent motionEvent) {
-    if ((!isEnabled() || interrupted) && isInProgress) {
+    if (interrupted) {
       interrupted = false;
       gestureStopped();
+      return false;
     }
 
     if (velocityTracker != null) {
@@ -114,10 +115,21 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
     return isInProgress;
   }
 
+  @Override
+  public void setEnabled(boolean enabled) {
+    super.setEnabled(enabled);
+    if (!enabled) {
+      interrupt();
+    }
+  }
+
   /**
-   *
+   * Interrupt a gesture by stopping it's execution immediately.
+   * Forces gesture detector to meet start conditions again in order to resume.
    */
   public void interrupt() {
-    this.interrupted = true;
+    if (isInProgress()) {
+      this.interrupted = true;
+    }
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -114,6 +114,9 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
     return isInProgress;
   }
 
+  /**
+   *
+   */
   public void interrupt() {
     this.interrupted = true;
   }

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -33,7 +33,7 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
 
   @Override
   protected boolean analyzeEvent(MotionEvent motionEvent) {
-    if (!isEnabled()) {
+    if (!isEnabled() && isInProgress) {
       gestureStopped();
     }
 

--- a/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ProgressiveGesture.java
@@ -25,7 +25,7 @@ public abstract class ProgressiveGesture<L> extends MultiFingerGesture<L> {
   float velocityX;
   float velocityY;
 
-  protected ProgressiveGesture(Context context, AndroidGesturesManager gesturesManager) {
+  public ProgressiveGesture(Context context, AndroidGesturesManager gesturesManager) {
     super(context, gesturesManager);
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
@@ -155,18 +155,6 @@ public class RotateGestureDetector extends ProgressiveGesture<RotateGestureDetec
     return angularVelocity;
   }
 
-  void startAnimation() {
-    float angularVelocity = Math.abs(calculateAngularVelocityVector(velocityX, velocityY));
-    if (deltaSinceLast < 0) {
-      angularVelocity = -angularVelocity;
-    }
-
-    valueAnimator.setFloatValues(angularVelocity, 0f);
-    valueAnimator.setDuration((long) (Math.abs(angularVelocity) * 100));
-    valueAnimator.setInterpolator(getInterpolator());
-    valueAnimator.start();
-  }
-
   /**
    * Get the threshold angle between first and current fingers position
    * for this detector to actually qualify it as a rotation gesture.

--- a/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
@@ -123,7 +123,7 @@ public class RotateGestureDetector extends ProgressiveGesture<RotateGestureDetec
       velocityY = 0;
     }
 
-    float angularVelocity = Math.abs(calculateAngularVelocityVector(velocityX, velocityY));
+    float angularVelocity = calculateAngularVelocityVector(velocityX, velocityY);
     listener.onRotateEnd(this, velocityX, velocityY, angularVelocity);
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
@@ -111,7 +111,7 @@ public class RotateGestureDetector extends ProgressiveGesture<RotateGestureDetec
 
   @Override
   protected boolean canExecute(int invokedGestureType) {
-    return Math.abs(deltaSinceStart) > angleThreshold && super.canExecute(invokedGestureType);
+    return Math.abs(deltaSinceStart) >= angleThreshold && super.canExecute(invokedGestureType);
   }
 
   @Override

--- a/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
@@ -1,12 +1,8 @@
 package com.mapbox.android.gestures;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
-import android.view.animation.DecelerateInterpolator;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
@@ -24,7 +24,7 @@ public class RotateGestureDetector extends ProgressiveGesture<RotateGestureDetec
   float deltaSinceStart;
   float deltaSinceLast;
 
-  protected RotateGestureDetector(Context context, AndroidGesturesManager gesturesManager) {
+  public RotateGestureDetector(Context context, AndroidGesturesManager gesturesManager) {
     super(context, gesturesManager);
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
@@ -103,7 +103,7 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
 
   @Override
   protected boolean canExecute(int invokedGestureType) {
-    return Math.abs(deltaPixelsSinceStart) > pixelDeltaThreshold
+    return Math.abs(deltaPixelsSinceStart) >= pixelDeltaThreshold
       && super.canExecute(invokedGestureType);
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
@@ -58,9 +58,11 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
     /**
      * Indicates that the shove gesture ended.
      *
+     * @param velocityX velocityX of the gesture in the moment of lifting the fingers
+     * @param velocityY velocityY of the gesture in the moment of lifting the fingers
      * @param detector this detector
      */
-    void onShoveEnd(ShoveGestureDetector detector);
+    void onShoveEnd(ShoveGestureDetector detector, float velocityX, float velocityY);
   }
 
   public static class SimpleOnShoveGestureListener implements OnShoveGestureListener {
@@ -75,7 +77,7 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
     }
 
     @Override
-    public void onShoveEnd(ShoveGestureDetector detector) {
+    public void onShoveEnd(ShoveGestureDetector detector, float velocityX, float velocityY) {
       // No Implementation
     }
   }
@@ -113,7 +115,7 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
   @Override
   protected void gestureStopped() {
     super.gestureStopped();
-    listener.onShoveEnd(this);
+    listener.onShoveEnd(this, velocityX, velocityY);
   }
 
   @Override

--- a/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
@@ -60,10 +60,14 @@ public class StandardScaleGestureDetector extends
   }
 
   boolean innerOnScale(ScaleGestureDetector detector) {
+    if (startSpan == 0) {
+      startSpan = detector.getCurrentSpan();
+    }
+
     spanDeltaSinceStart = Math.abs(startSpan - detector.getCurrentSpan());
 
     // If we can execute but haven't started immediately because there is a threshold as well, check it
-    if (!isInProgress() && spanDeltaSinceStart > spanSinceStartThreshold) {
+    if (!isInProgress() && canExecute(GESTURE_TYPE_SCALE) && spanDeltaSinceStart >= spanSinceStartThreshold) {
       if (listener.onScaleBegin(StandardScaleGestureDetector.this)) {
         gestureStarted();
         return true;
@@ -122,6 +126,12 @@ public class StandardScaleGestureDetector extends
       listener.onScaleEnd(StandardScaleGestureDetector.this, velocityX, velocityY);
       stopConfirmed = false;
     }
+  }
+
+  @Override
+  public void interrupt() {
+    super.interrupt();
+    stopConfirmed = true;
   }
 
   @NonNull

--- a/library/src/test/java/com/mapbox/android/gestures/MoveGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/MoveGestureDetectorTest.java
@@ -28,7 +28,8 @@ public class MoveGestureDetectorTest extends
 
     verify(listener, times(1)).onMoveBegin(gestureDetector);
     verify(listener, times(1)).onMove(gestureDetector, 0, 0);
-    verify(listener, times(1)).onMoveEnd(gestureDetector);
+    verify(listener, times(1)).onMoveEnd(
+      gestureDetector, gestureDetector.velocityX, gestureDetector.velocityY);
   }
 
   @Test
@@ -60,6 +61,8 @@ public class MoveGestureDetectorTest extends
     gestureDetector.onTouchEvent(pointerUpEvent);
     MotionEvent upEvent = TestUtils.getMotionEvent(MotionEvent.ACTION_POINTER_UP, 200, 100, pointerUpEvent);
     gestureDetector.onTouchEvent(upEvent);
-    verify(listener, times(1)).onMoveEnd(gestureDetector);
+    verify(listener, times(1)).onMoveEnd(
+      gestureDetector, gestureDetector.velocityX, gestureDetector.velocityY
+    );
   }
 }

--- a/library/src/test/java/com/mapbox/android/gestures/RotateGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/RotateGestureDetectorTest.java
@@ -50,15 +50,15 @@ public class RotateGestureDetectorTest extends
       gestureDetector.deltaSinceLast, gestureDetector.deltaSinceStart);
 
     // stopping
-    gestureDetector.deltaSinceLast = 0f; // to stop gesture without animation
-    doNothing().when(gestureDetector).startAnimation();
     gestureDetector.gestureStopped();
 
     // not starting because threshold not met
     gestureDetector.analyzeMovement();
 
     verify(listener, times(1)).onRotateBegin(gestureDetector);
-    verify(listener, times(1)).onRotateEnd(gestureDetector);
+    verify(listener, times(1)).onRotateEnd(
+      gestureDetector, gestureDetector.velocityX, gestureDetector.velocityY,
+      gestureDetector.calculateAngularVelocityVector(gestureDetector.velocityX, gestureDetector.velocityY));
   }
 
   @Test

--- a/library/src/test/java/com/mapbox/android/gestures/RotateGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/RotateGestureDetectorTest.java
@@ -5,7 +5,6 @@ import android.graphics.PointF;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/library/src/test/java/com/mapbox/android/gestures/ShoveGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/ShoveGestureDetectorTest.java
@@ -73,7 +73,8 @@ public class ShoveGestureDetectorTest extends
     gestureDetector.analyzeMovement();
 
     verify(listener, times(2)).onShoveBegin(gestureDetector);
-    verify(listener, times(1)).onShoveEnd(gestureDetector);
+    verify(listener, times(1)).onShoveEnd(
+      gestureDetector, gestureDetector.velocityX, gestureDetector.velocityY);
   }
 
   @Test

--- a/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
@@ -2,6 +2,7 @@ package com.mapbox.android.gestures;
 
 import org.junit.Test;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,6 +21,7 @@ public class StandardScaleGestureDetectorTest extends
   public void analyzeMovementTest() throws Exception {
     when(listener.onScaleBegin(gestureDetector)).thenReturn(true);
     when(listener.onScale(gestureDetector)).thenReturn(true);
+    doReturn(false).when(gestureDetector).isSloppyGesture();
 
     // threshold not met
     gestureDetector.spanDeltaSinceStart = gestureDetector.getSpanSinceStartThreshold() / 2;
@@ -43,6 +45,16 @@ public class StandardScaleGestureDetectorTest extends
     //scale
     gestureDetector.innerOnScale(gestureDetector.getUnderlyingScaleGestureDetector());
 
+    //interrupt
+    gestureDetector.interrupt();
+    gestureDetector.analyzeEvent(emptyMotionEvent);
+
+    //stopping, then starting because was interrupted
+    gestureDetector.innerOnScale(gestureDetector.getUnderlyingScaleGestureDetector());
+
+    //scale
+    gestureDetector.innerOnScale(gestureDetector.getUnderlyingScaleGestureDetector());
+
     // stopping
     gestureDetector.innerOnScaleEnd(gestureDetector.getUnderlyingScaleGestureDetector());
 
@@ -54,9 +66,9 @@ public class StandardScaleGestureDetectorTest extends
     // stopping without surpassing threshold, no callback invocations
     gestureDetector.innerOnScaleEnd(gestureDetector.getUnderlyingScaleGestureDetector());
 
-    verify(listener, times(2)).onScaleBegin(gestureDetector);
-    verify(listener, times(2)).onScale(gestureDetector);
-    verify(listener, times(2)).onScaleEnd(
+    verify(listener, times(3)).onScaleBegin(gestureDetector);
+    verify(listener, times(3)).onScale(gestureDetector);
+    verify(listener, times(3)).onScaleEnd(
       gestureDetector, gestureDetector.velocityX, gestureDetector.velocityY);
   }
 }

--- a/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
@@ -21,7 +21,6 @@ public class StandardScaleGestureDetectorTest extends
   public void analyzeMovementTest() throws Exception {
     when(listener.onScaleBegin(gestureDetector)).thenReturn(true);
     when(listener.onScale(gestureDetector)).thenReturn(true);
-    doNothing().when(gestureDetector).startAnimation(0);
 
     // threshold not met
     gestureDetector.spanDeltaSinceStart = gestureDetector.getSpanSinceStartThreshold() / 2;
@@ -50,7 +49,7 @@ public class StandardScaleGestureDetectorTest extends
 
     // threshold not met
     gestureDetector.setSpanSinceStartThreshold(gestureDetector.getDefaultSpanSinceStartThreshold());
-    gestureDetector.startSpan = gestureDetector.getSpanThreshold() / 2;
+    gestureDetector.startSpan = gestureDetector.getSpanSinceStartThreshold() / 2;
     gestureDetector.innerOnScaleBegin(gestureDetector.getUnderlyingScaleGestureDetector());
     gestureDetector.innerOnScale(gestureDetector.getUnderlyingScaleGestureDetector());
     // stopping without surpassing threshold, no callback invocations
@@ -58,6 +57,7 @@ public class StandardScaleGestureDetectorTest extends
 
     verify(listener, times(2)).onScaleBegin(gestureDetector);
     verify(listener, times(2)).onScale(gestureDetector);
-    verify(listener, times(2)).onScaleEnd(gestureDetector);
+    verify(listener, times(2)).onScaleEnd(
+      gestureDetector, gestureDetector.velocityX, gestureDetector.velocityY);
   }
 }

--- a/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
@@ -37,19 +37,27 @@ public class StandardScaleGestureDetectorTest extends
     // stopping
     gestureDetector.innerOnScaleEnd(gestureDetector.getUnderlyingScaleGestureDetector());
 
+    //interrupt
+    gestureDetector.interrupt();
+
     // no threshold, starting immediately
     gestureDetector.setSpanSinceStartThreshold(0);
     gestureDetector.startSpan = 0;
     gestureDetector.innerOnScaleBegin(gestureDetector.getUnderlyingScaleGestureDetector());
+
+    doReturn(emptyMotionEvent).when(gestureDetector).getCurrentEvent();
+    //doesn't call stop because wasn't in progress when interrupted
+    gestureDetector.analyzeEvent(emptyMotionEvent);
 
     //scale
     gestureDetector.innerOnScale(gestureDetector.getUnderlyingScaleGestureDetector());
 
     //interrupt
     gestureDetector.interrupt();
+    //stopping because was interrupted
     gestureDetector.analyzeEvent(emptyMotionEvent);
 
-    //stopping, then starting because was interrupted
+    //starting again because was interrupted
     gestureDetector.innerOnScale(gestureDetector.getUnderlyingScaleGestureDetector());
 
     //scale

--- a/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
@@ -2,7 +2,6 @@ package com.mapbox.android.gestures;
 
 import org.junit.Test;
 
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
This PR adds some minor tweaks and improvements such as:
- enabled/disabled state of a gesture detector manipulated with `setEnabled()` method
- `interrupt()` method that stops the execution of a `ProgressiveGesture` and requires it to meet the threshold again before re-starting
- ref. #13 by removing value animators and passing raw velocity values in end callbacks