### PR TITLE
Using dimens for default pixel threshold values

### DIFF
--- a/app/src/main/java/com/mapbox/android/gestures/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/android/gestures/testapp/MainActivity.java
@@ -135,7 +135,7 @@ public class MainActivity extends AppCompatActivity {
 
     rotateThresholdProgress = (SeekBar) findViewById(R.id.progress_threshold_rotate);
     rotateThresholdProgress.setProgress(
-      (int) androidGesturesManager.getRotateGestureDetector().getDefaultAngleThreshold());
+      (int) androidGesturesManager.getRotateGestureDetector().getAngleThreshold());
 
     rotateThresholdProgress.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
       @Override
@@ -154,7 +154,7 @@ public class MainActivity extends AppCompatActivity {
 
     scaleThresholdProgress = (SeekBar) findViewById(R.id.progress_threshold_scale);
     scaleThresholdProgress.setProgress(
-      (int) androidGesturesManager.getStandardScaleGestureDetector().getDefaultSpanSinceStartThreshold());
+      (int) androidGesturesManager.getStandardScaleGestureDetector().getSpanSinceStartThreshold());
 
     scaleThresholdProgress.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
       @Override

--- a/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
+++ b/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
@@ -68,7 +68,17 @@ public class AndroidGesturesManager {
    * @param context activity's context
    */
   public AndroidGesturesManager(Context context) {
-    this(context, new ArrayList<Set<Integer>>());
+    this(context, true);
+  }
+
+  /**
+   * Creates a new instance of the {@link AndroidGesturesManager}.
+   *
+   * @param context                activity's context
+   * @param applyDefaultThresholds if true, default gestures thresholds and adjustments will be applied
+   */
+  public AndroidGesturesManager(Context context, boolean applyDefaultThresholds) {
+    this(context, new ArrayList<Set<Integer>>(), applyDefaultThresholds);
   }
 
   /**
@@ -85,22 +95,23 @@ public class AndroidGesturesManager {
    */
   @SafeVarargs
   public AndroidGesturesManager(Context context, Set<Integer>... exclusiveGestures) {
-    this(context, Arrays.asList(exclusiveGestures));
+    this(context, Arrays.asList(exclusiveGestures), true);
   }
 
   /**
    * Creates a new instance of the {@link AndroidGesturesManager}.
    *
-   * @param context           Activity's context
-   * @param exclusiveGestures a list of sets of {@link GestureType}s that <b>should not</b> be invoked at the same.
-   *                          This means that when a set contains a {@link ProgressiveGesture} and this gestures
-   *                          is in progress no other gestures from the set will be invoked.
-   *                          <p>
-   *                          At the moment {@link #GESTURE_TYPE_SCROLL} is not interpreted as a progressive gesture
-   *                          because it is not implemented this way by the
-   *                          {@link android.support.v4.view.GestureDetectorCompat}.
+   * @param context                Activity's context
+   * @param exclusiveGestures      a list of sets of {@link GestureType}s that <b>should not</b> be invoked at the same.
+   *                               This means that when a set contains a {@link ProgressiveGesture} and this gestures
+   *                               is in progress no other gestures from the set will be invoked.
+   *                               <p>
+   *                               At the moment {@link #GESTURE_TYPE_SCROLL} is not interpreted as
+   *                               a progressive gesture because it is not implemented this way by the
+   *                               {@link android.support.v4.view.GestureDetectorCompat}.
+   * @param applyDefaultThresholds if true, default gestures thresholds and adjustments will be applied
    */
-  public AndroidGesturesManager(Context context, List<Set<Integer>> exclusiveGestures) {
+  public AndroidGesturesManager(Context context, List<Set<Integer>> exclusiveGestures, boolean applyDefaultThresholds) {
     this.mutuallyExclusiveGestures.addAll(exclusiveGestures);
 
     rotateGestureDetector = new RotateGestureDetector(context, this);
@@ -116,6 +127,40 @@ public class AndroidGesturesManager {
     detectors.add(multiFingerTapGestureDetector);
     detectors.add(moveGestureDetector);
     detectors.add(standardGestureDetector);
+
+    if (applyDefaultThresholds) {
+      initDefaultThresholds();
+    }
+  }
+
+  private void initDefaultThresholds() {
+    for (BaseGesture detector : detectors) {
+      if (detector instanceof MultiFingerTapGestureDetector) {
+        ((MultiFingerGesture) detector).setSpanThreshold(R.dimen.mapbox_defaultMutliFingerSpanThreshold);
+      }
+
+      if (detector instanceof StandardScaleGestureDetector) {
+        ((StandardScaleGestureDetector) detector).setSpanSinceStartThreshold(
+          R.dimen.mapbox_defaultScaleSpanSinceStartThreshold);
+      }
+
+      if (detector instanceof ShoveGestureDetector) {
+        ((ShoveGestureDetector) detector).setPixelDeltaThreshold(R.dimen.mapbox_defaultShovePixelThreshold);
+        ((ShoveGestureDetector) detector).setMaxShoveAngle(Constants.DEFAULT_SHOVE_MAX_ANGLE);
+      }
+
+      if (detector instanceof MultiFingerTapGestureDetector) {
+        ((MultiFingerTapGestureDetector) detector).setMultiFingerTapMovementThreshold(
+          R.dimen.mapbox_defaultMultiTapMovementThreshold);
+
+        ((MultiFingerTapGestureDetector) detector).setMultiFingerTapTimeThreshold(
+          Constants.DEFAULT_MULTI_TAP_TIME_THRESHOLD);
+      }
+
+      if (detector instanceof RotateGestureDetector) {
+        ((RotateGestureDetector) detector).setAngleThreshold(Constants.DEFAULT_ROTATE_ANGLE_THRESHOLD);
+      }
+    }
   }
 
   /**

--- a/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
+++ b/library/src/main/java/com/mapbox/android/gestures/AndroidGesturesManager.java
@@ -136,21 +136,21 @@ public class AndroidGesturesManager {
   private void initDefaultThresholds() {
     for (BaseGesture detector : detectors) {
       if (detector instanceof MultiFingerTapGestureDetector) {
-        ((MultiFingerGesture) detector).setSpanThreshold(R.dimen.mapbox_defaultMutliFingerSpanThreshold);
+        ((MultiFingerGesture) detector).setSpanThresholdResource(R.dimen.mapbox_defaultMutliFingerSpanThreshold);
       }
 
       if (detector instanceof StandardScaleGestureDetector) {
-        ((StandardScaleGestureDetector) detector).setSpanSinceStartThreshold(
+        ((StandardScaleGestureDetector) detector).setSpanSinceStartThresholdResource(
           R.dimen.mapbox_defaultScaleSpanSinceStartThreshold);
       }
 
       if (detector instanceof ShoveGestureDetector) {
-        ((ShoveGestureDetector) detector).setPixelDeltaThreshold(R.dimen.mapbox_defaultShovePixelThreshold);
+        ((ShoveGestureDetector) detector).setPixelDeltaThresholdResource(R.dimen.mapbox_defaultShovePixelThreshold);
         ((ShoveGestureDetector) detector).setMaxShoveAngle(Constants.DEFAULT_SHOVE_MAX_ANGLE);
       }
 
       if (detector instanceof MultiFingerTapGestureDetector) {
-        ((MultiFingerTapGestureDetector) detector).setMultiFingerTapMovementThreshold(
+        ((MultiFingerTapGestureDetector) detector).setMultiFingerTapMovementThresholdResource(
           R.dimen.mapbox_defaultMultiTapMovementThreshold);
 
         ((MultiFingerTapGestureDetector) detector).setMultiFingerTapTimeThreshold(

--- a/library/src/main/java/com/mapbox/android/gestures/BaseGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/BaseGesture.java
@@ -13,7 +13,7 @@ import java.util.Set;
  */
 @UiThread
 public abstract class BaseGesture<L> {
-  final Context context;
+  protected final Context context;
   private final AndroidGesturesManager gesturesManager;
   private MotionEvent currentEvent;
   private MotionEvent previousEvent;
@@ -23,7 +23,7 @@ public abstract class BaseGesture<L> {
   /**
    * Listener that will be called with gesture events/updates.
    */
-  L listener;
+  protected L listener;
 
   public BaseGesture(Context context, AndroidGesturesManager gesturesManager) {
     this.context = context;

--- a/library/src/main/java/com/mapbox/android/gestures/Constants.java
+++ b/library/src/main/java/com/mapbox/android/gestures/Constants.java
@@ -1,23 +1,19 @@
 package com.mapbox.android.gestures;
 
-final class Constants {
-  // MultiFinger
-  static final float DEFAULT_MULTI_FINGER_SPAN_THRESHOLD = 290f;
+public final class Constants {
 
-  // Rotate
-  static final float DEFAULT_ROTATE_ANGLE_THRESHOLD = 15.3f;
+  /**
+   * Default angle change required in rotation movement to register rotate gesture./
+   */
+  public static final float DEFAULT_ROTATE_ANGLE_THRESHOLD = 15.3f;
 
-  // Scale
-  static final float DEFAULT_SCALE_SPAN_SINCE_START_THRESHOLD = 20f;
+  /**
+   * Default angle between pointers (starting from horizontal line) required to abort shove gesture.
+   */
+  public static final float DEFAULT_SHOVE_MAX_ANGLE = 20f;
 
-  // Shove
-  static final float DEFAULT_SHOVE_MAX_ANGLE = 20f;
-  static final float DEFAULT_SHOVE_PIXEL_THRESHOLD = 100f;
-
-  // Tap
-  static final long DEFAULT_MULTI_TAP_TIME_THRESHOLD = 150L;
-  static final float DEFAULT_MULTI_TAP_MOVEMENT_THRESHOLD = 15L;
-
-  // Move
-  static final float DEFAULT_MOVE_THRESHOLD = 0f;
+  /**
+   * Default time within which pointers need to leave the screen to register tap gesture.
+   */
+  public static final long DEFAULT_MULTI_TAP_TIME_THRESHOLD = 150L;
 }

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -224,7 +224,7 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
    *
    * @param moveThresholdDimen delta threshold
    */
-  public void setMoveThreshold(@DimenRes int moveThresholdDimen) {
+  public void setMoveThresholdResource(@DimenRes int moveThresholdDimen) {
     setMoveThreshold(context.getResources().getDimension(moveThresholdDimen));
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MoveGestureDetector.java
@@ -2,6 +2,7 @@ package com.mapbox.android.gestures;
 
 import android.content.Context;
 import android.graphics.PointF;
+import android.support.annotation.DimenRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 import android.view.MotionEvent;
@@ -37,7 +38,7 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
     handledTypes.add(GESTURE_TYPE_MOVE);
   }
 
-  private float moveThreshold = Constants.DEFAULT_MOVE_THRESHOLD;
+  private float moveThreshold;
   private final Map<Integer, MoveDistancesObject> moveDistancesObjectMap = new HashMap<>();
 
   public MoveGestureDetector(Context context, AndroidGesturesManager gesturesManager) {
@@ -209,21 +210,22 @@ public class MoveGestureDetector extends ProgressiveGesture<MoveGestureDetector.
 
   /**
    * Set the delta pixel threshold required to qualify it as a move gesture.
+   * <p>
+   * We encourage to set those values from dimens to accommodate for various screen sizes.
    *
-   * @param moveThreshold delta pixel threshold
+   * @param moveThreshold delta threshold
    */
   public void setMoveThreshold(float moveThreshold) {
     this.moveThreshold = moveThreshold;
   }
 
   /**
-   * Get the default delta pixel threshold required to qualify it as a move gesture.
+   * Set the delta dp threshold required to qualify it as a move gesture.
    *
-   * @return delta pixel threshold
-   * @see Constants#DEFAULT_MOVE_THRESHOLD
+   * @param moveThresholdDimen delta threshold
    */
-  public float getDefaultMoveThreshold() {
-    return Constants.DEFAULT_MOVE_THRESHOLD;
+  public void setMoveThreshold(@DimenRes int moveThresholdDimen) {
+    setMoveThreshold(context.getResources().getDimension(moveThresholdDimen));
   }
 
   /**

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
@@ -380,7 +380,7 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
    *
    * @param spanThresholdDimen minimum span
    */
-  public void setSpanThreshold(@DimenRes int spanThresholdDimen) {
+  public void setSpanThresholdResource(@DimenRes int spanThresholdDimen) {
     setSpanThreshold(context.getResources().getDimension(spanThresholdDimen));
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
@@ -2,6 +2,7 @@ package com.mapbox.android.gestures;
 
 import android.content.Context;
 import android.graphics.PointF;
+import android.support.annotation.DimenRes;
 import android.support.annotation.UiThread;
 import android.util.DisplayMetrics;
 import android.view.MotionEvent;
@@ -35,7 +36,7 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
 
   private final float edgeSlop;
 
-  private float spanThreshold = Constants.DEFAULT_MULTI_FINGER_SPAN_THRESHOLD;
+  private float spanThreshold;
 
   /**
    * A list that holds IDs of currently active pointers in an order of activation.
@@ -364,7 +365,9 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
   }
 
   /**
-   * Set minimum span between any pair of finger that is required to pass motion events to this detector.
+   * Set minimum span in pixels between any pair of finger that is required to pass motion events to this detector.
+   * <p>
+   * We encourage to set those values from dimens to accommodate for various screen sizes.
    *
    * @param spanThreshold minimum span
    */
@@ -373,12 +376,11 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
   }
 
   /**
-   * Get default minimum span between any pair of finger that is required to pass motion events to this detector.
+   * Set minimum span in dp between any pair of finger that is required to pass motion events to this detector.
    *
-   * @return default minimum span
-   * @see Constants#DEFAULT_MULTI_FINGER_SPAN_THRESHOLD
+   * @param spanThresholdDimen minimum span
    */
-  public float getDefaultSpanThreshold() {
-    return Constants.DEFAULT_MULTI_FINGER_SPAN_THRESHOLD;
+  public void setSpanThreshold(@DimenRes int spanThresholdDimen) {
+    setSpanThreshold(context.getResources().getDimension(spanThresholdDimen));
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerTapGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerTapGestureDetector.java
@@ -149,7 +149,7 @@ public class MultiFingerTapGestureDetector extends
    *
    * @param multiFingerTapMovementThresholdDimen movement threshold.
    */
-  public void setMultiFingerTapMovementThreshold(@DimenRes int multiFingerTapMovementThresholdDimen) {
+  public void setMultiFingerTapMovementThresholdResource(@DimenRes int multiFingerTapMovementThresholdDimen) {
     setMultiFingerTapMovementThreshold(context.getResources().getDimension(multiFingerTapMovementThresholdDimen));
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerTapGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerTapGestureDetector.java
@@ -1,6 +1,7 @@
 package com.mapbox.android.gestures;
 
 import android.content.Context;
+import android.support.annotation.DimenRes;
 import android.support.annotation.UiThread;
 import android.view.MotionEvent;
 
@@ -18,12 +19,12 @@ public class MultiFingerTapGestureDetector extends
   /**
    * Maximum time in millis to lift the fingers to register a tap event.
    */
-  private long multiFingerTapTimeThreshold = Constants.DEFAULT_MULTI_TAP_TIME_THRESHOLD;
+  private long multiFingerTapTimeThreshold;
 
   /**
    * Maximum movement in pixels allowed for any finger before rejecting this gesture.
    */
-  private float multiFingerTapMovementThreshold = Constants.DEFAULT_MULTI_TAP_MOVEMENT_THRESHOLD;
+  private float multiFingerTapMovementThreshold;
   private boolean invalidMovement;
   private boolean pointerLifted;
   private int lastPointersDownCount;
@@ -124,15 +125,6 @@ public class MultiFingerTapGestureDetector extends
   }
 
   /**
-   * Get default maximum time in millis that fingers can have a contact with the screen before rejecting this gesture.
-   *
-   * @return default maximum touch time for tap gesture.
-   */
-  public long getDefaultMultiFingerTapTimeThreshold() {
-    return Constants.DEFAULT_MULTI_TAP_TIME_THRESHOLD;
-  }
-
-  /**
    * Get maximum movement allowed for any finger before rejecting this gesture.
    *
    * @return movement threshold in pixels.
@@ -142,20 +134,22 @@ public class MultiFingerTapGestureDetector extends
   }
 
   /**
-   * Get maximum movement allowed for any finger before rejecting this gesture.
+   * Set maximum movement allowed in pixels for any finger before rejecting this gesture.
+   * <p>
+   * We encourage to set those values from dimens to accommodate for various screen sizes.
    *
-   * @param multiFingerTapMovementThreshold movement threshold in pixels.
+   * @param multiFingerTapMovementThreshold movement threshold.
    */
   public void setMultiFingerTapMovementThreshold(float multiFingerTapMovementThreshold) {
     this.multiFingerTapMovementThreshold = multiFingerTapMovementThreshold;
   }
 
   /**
-   * Get default maximum movement allowed for any finger before rejecting this gesture.
+   * Set maximum movement allowed in dp for any finger before rejecting this gesture.
    *
-   * @return default movement threshold in pixels.
+   * @param multiFingerTapMovementThresholdDimen movement threshold.
    */
-  public float getDefaultMultiFingerTapMovementThreshold() {
-    return Constants.DEFAULT_MULTI_TAP_MOVEMENT_THRESHOLD;
+  public void setMultiFingerTapMovementThreshold(@DimenRes int multiFingerTapMovementThresholdDimen) {
+    setMultiFingerTapMovementThreshold(context.getResources().getDimension(multiFingerTapMovementThresholdDimen));
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/RotateGestureDetector.java
@@ -20,7 +20,7 @@ public class RotateGestureDetector extends ProgressiveGesture<RotateGestureDetec
     handledTypes.add(GESTURE_TYPE_ROTATE);
   }
 
-  private float angleThreshold = Constants.DEFAULT_ROTATE_ANGLE_THRESHOLD;
+  private float angleThreshold;
   float deltaSinceStart;
   float deltaSinceLast;
 
@@ -169,16 +169,5 @@ public class RotateGestureDetector extends ProgressiveGesture<RotateGestureDetec
    */
   public void setAngleThreshold(float angleThreshold) {
     this.angleThreshold = angleThreshold;
-  }
-
-  /**
-   * Get the threshold angle between first and current fingers position
-   * for this detector to actually qualify it as a rotation gesture.
-   *
-   * @return Angle threshold for rotation gesture
-   * @see Constants#DEFAULT_ROTATE_ANGLE_THRESHOLD
-   */
-  public float getDefaultAngleThreshold() {
-    return Constants.DEFAULT_ROTATE_ANGLE_THRESHOLD;
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
@@ -1,6 +1,7 @@
 package com.mapbox.android.gestures;
 
 import android.content.Context;
+import android.support.annotation.DimenRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 
@@ -20,8 +21,8 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
     handledTypes.add(GESTURE_TYPE_SHOVE);
   }
 
-  private float maxShoveAngle = Constants.DEFAULT_SHOVE_MAX_ANGLE;
-  private float pixelDeltaThreshold = Constants.DEFAULT_SHOVE_PIXEL_THRESHOLD;
+  private float maxShoveAngle;
+  private float pixelDeltaThreshold;
   float deltaPixelsSinceStart;
   float deltaPixelSinceLast;
 
@@ -60,7 +61,7 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
      *
      * @param velocityX velocityX of the gesture in the moment of lifting the fingers
      * @param velocityY velocityY of the gesture in the moment of lifting the fingers
-     * @param detector this detector
+     * @param detector  this detector
      */
     void onShoveEnd(ShoveGestureDetector detector, float velocityX, float velocityY);
   }
@@ -158,25 +159,26 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
 
   /**
    * Set the delta pixel threshold required to qualify it as a shove gesture.
+   * <p>
+   * We encourage to set those values from dimens to accommodate for various screen sizes.
    *
-   * @param pixelDeltaThreshold delta pixel threshold
+   * @param pixelDeltaThreshold delta threshold
    */
   public void setPixelDeltaThreshold(float pixelDeltaThreshold) {
     this.pixelDeltaThreshold = pixelDeltaThreshold;
   }
 
   /**
-   * Get the default delta pixel threshold required to qualify it as a shove gesture.
+   * Set the delta dp threshold required to qualify it as a shove gesture.
    *
-   * @return delta pixel threshold
-   * @see Constants#DEFAULT_SHOVE_PIXEL_THRESHOLD
+   * @param pixelDeltaThresholdDimen delta threshold
    */
-  public float getDefaultPixelDeltaThreshold() {
-    return Constants.DEFAULT_SHOVE_PIXEL_THRESHOLD;
+  public void setPixelDeltaThreshold(@DimenRes int pixelDeltaThresholdDimen) {
+    setPixelDeltaThreshold(context.getResources().getDimension(pixelDeltaThresholdDimen));
   }
 
   /**
-   * Get the maximum allowed angle between fingers to qualify it as a shove gesture.
+   * Get the maximum allowed angle between fingers, measured from the horizontal line, to qualify it as a shove gesture.
    *
    * @return maximum allowed angle
    */
@@ -185,21 +187,11 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
   }
 
   /**
-   * Set the maximum allowed angle between fingers to qualify it as a shove gesture.
+   * Set the maximum allowed angle between fingers, measured from the horizontal line, to qualify it as a shove gesture.
    *
    * @param maxShoveAngle maximum allowed angle
    */
   public void setMaxShoveAngle(float maxShoveAngle) {
     this.maxShoveAngle = maxShoveAngle;
-  }
-
-  /**
-   * Get the default maximum allowed angle between fingers to qualify it as a shove gesture.
-   *
-   * @return default maximum allowed angle
-   * @see Constants#DEFAULT_SHOVE_MAX_ANGLE
-   */
-  public float getDefaultMaxShoveAngle() {
-    return Constants.DEFAULT_SHOVE_MAX_ANGLE;
   }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/ShoveGestureDetector.java
@@ -173,7 +173,7 @@ public class ShoveGestureDetector extends ProgressiveGesture<ShoveGestureDetecto
    *
    * @param pixelDeltaThresholdDimen delta threshold
    */
-  public void setPixelDeltaThreshold(@DimenRes int pixelDeltaThresholdDimen) {
+  public void setPixelDeltaThresholdResource(@DimenRes int pixelDeltaThresholdDimen) {
     setPixelDeltaThreshold(context.getResources().getDimension(pixelDeltaThresholdDimen));
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
@@ -233,7 +233,7 @@ public class StandardScaleGestureDetector extends
    *
    * @param spanSinceStartThresholdDimen delta span threshold
    */
-  public void setSpanSinceStartThreshold(@DimenRes int spanSinceStartThresholdDimen) {
+  public void setSpanSinceStartThresholdResource(@DimenRes int spanSinceStartThresholdDimen) {
     setSpanSinceStartThreshold(context.getResources().getDimension(spanSinceStartThresholdDimen));
   }
 

--- a/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
@@ -1,6 +1,7 @@
 package com.mapbox.android.gestures;
 
 import android.content.Context;
+import android.support.annotation.DimenRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 import android.view.MotionEvent;
@@ -34,7 +35,7 @@ public class StandardScaleGestureDetector extends
 
   float startSpan;
   float spanDeltaSinceStart;
-  private float spanSinceStartThreshold = Constants.DEFAULT_SCALE_SPAN_SINCE_START_THRESHOLD;
+  private float spanSinceStartThreshold;
 
   public StandardScaleGestureDetector(Context context, AndroidGesturesManager androidGesturesManager) {
     super(context, androidGesturesManager);
@@ -205,7 +206,7 @@ public class StandardScaleGestureDetector extends
   }
 
   /**
-   * Get the threshold span between initial fingers position and current needed
+   * Get the threshold span in pixels between initial fingers position and current needed
    * for this detector to qualify it as a scale gesture.
    *
    * @return span threshold
@@ -215,8 +216,10 @@ public class StandardScaleGestureDetector extends
   }
 
   /**
-   * Set the threshold span between initial fingers position and current needed
+   * Set the threshold span in pixels between initial fingers position and current needed
    * for this detector to qualify it as a scale gesture.
+   * <p>
+   * We encourage to set those values from dimens to accommodate for various screen sizes.
    *
    * @param spanSinceStartThreshold delta span threshold
    */
@@ -225,14 +228,13 @@ public class StandardScaleGestureDetector extends
   }
 
   /**
-   * Get the default threshold span between initial fingers position and current needed
+   * Set the threshold span in dp between initial fingers position and current needed
    * for this detector to qualify it as a scale gesture.
    *
-   * @return default span threshold
-   * @see Constants#DEFAULT_SCALE_SPAN_SINCE_START_THRESHOLD
+   * @param spanSinceStartThresholdDimen delta span threshold
    */
-  public float getDefaultSpanSinceStartThreshold() {
-    return Constants.DEFAULT_SCALE_SPAN_SINCE_START_THRESHOLD;
+  public void setSpanSinceStartThreshold(@DimenRes int spanSinceStartThresholdDimen) {
+    setSpanSinceStartThreshold(context.getResources().getDimension(spanSinceStartThresholdDimen));
   }
 
   /**

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!--Default minimum span required to process multi finger gestures-->
-    <dimen name="mapbox_defaultMutliFingerSpanThreshold">97dp</dimen>
+    <dimen name="mapbox_defaultMutliFingerSpanThreshold">55dp</dimen>
 
     <!--Default span change required between ScaleGestureDetector#onScaleBegin
     to StandardScaleGestureDetector#onScaleBegin.
@@ -9,7 +9,7 @@
     <dimen name="mapbox_defaultScaleSpanSinceStartThreshold">7dp</dimen>
 
     <!--Default Y change of pointers position required to register shove gesture-->
-    <dimen name="mapbox_defaultShovePixelThreshold">33dp</dimen>
+    <dimen name="mapbox_defaultShovePixelThreshold">16dp</dimen>
 
     <!--Default pointer's position change required to abort tap gesture-->
     <dimen name="mapbox_defaultMultiTapMovementThreshold">5dp</dimen>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--Default minimum span required to process multi finger gestures-->
+    <dimen name="mapbox_defaultMutliFingerSpanThreshold">97dp</dimen>
+
+    <!--Default span change required between ScaleGestureDetector#onScaleBegin
+    to StandardScaleGestureDetector#onScaleBegin.
+    In practice it just represents required span change to register scale gesture-->
+    <dimen name="mapbox_defaultScaleSpanSinceStartThreshold">7dp</dimen>
+
+    <!--Default Y change of pointers position required to register shove gesture-->
+    <dimen name="mapbox_defaultShovePixelThreshold">33dp</dimen>
+
+    <!--Default pointer's position change required to abort tap gesture-->
+    <dimen name="mapbox_defaultMultiTapMovementThreshold">5dp</dimen>
+</resources>

--- a/library/src/test/java/com/mapbox/android/gestures/AbstractGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/AbstractGestureDetectorTest.java
@@ -31,6 +31,26 @@ public abstract class AbstractGestureDetectorTest<K extends BaseGesture<L>, L> {
 
     context = RuntimeEnvironment.application.getApplicationContext();
     androidGesturesManager = new AndroidGesturesManager(context);
+
+    // reinitialize dimen thresholds
+    for (BaseGesture detector : androidGesturesManager.getDetectors()) {
+      if (detector instanceof MultiFingerTapGestureDetector) {
+        ((MultiFingerGesture) detector).setSpanThreshold(290f);
+      }
+
+      if (detector instanceof StandardScaleGestureDetector) {
+        ((StandardScaleGestureDetector) detector).setSpanSinceStartThreshold(20f);
+      }
+
+      if (detector instanceof ShoveGestureDetector) {
+        ((ShoveGestureDetector) detector).setPixelDeltaThreshold(100f);
+      }
+
+      if (detector instanceof MultiFingerTapGestureDetector) {
+        ((MultiFingerTapGestureDetector) detector).setMultiFingerTapMovementThreshold(15f);
+      }
+    }
+
     gestureDetector = getDetectorObject();
     gestureDetector.setListener(listener);
     emptyMotionEvent = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 250.0f, 250.0f, 0);

--- a/library/src/test/java/com/mapbox/android/gestures/AndroidGesturesManagerTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/AndroidGesturesManagerTest.java
@@ -38,7 +38,6 @@ public class AndroidGesturesManagerTest {
 
     set3.add(AndroidGesturesManager.GESTURE_TYPE_ROTATE);
     set3.add(AndroidGesturesManager.GESTURE_TYPE_SCALE);
-    //set3.add(AndroidGesturesManager.GESTURE_TYPE_MOVE);
 
     mutuallyExclusivesList.add(set1);
     mutuallyExclusivesList.add(set2);
@@ -47,7 +46,7 @@ public class AndroidGesturesManagerTest {
     androidGesturesManager =
       new AndroidGesturesManager(
         RuntimeEnvironment.application.getApplicationContext(),
-        mutuallyExclusivesList);
+        mutuallyExclusivesList, true);
   }
 
   @Test

--- a/library/src/test/java/com/mapbox/android/gestures/MoveGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/MoveGestureDetectorTest.java
@@ -14,7 +14,7 @@ public class MoveGestureDetectorTest extends
 
   @Override
   MoveGestureDetector getDetectorObject() {
-    return spy(new MoveGestureDetector(context, androidGesturesManager));
+    return spy(androidGesturesManager.getMoveGestureDetector());
   }
 
   @Test

--- a/library/src/test/java/com/mapbox/android/gestures/MultiFingerTapGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/MultiFingerTapGestureDetectorTest.java
@@ -34,7 +34,7 @@ public class MultiFingerTapGestureDetectorTest
 
   @Override
   MultiFingerTapGestureDetector getDetectorObject() {
-    return Mockito.spy(new MultiFingerTapGestureDetector(context, androidGesturesManager));
+    return Mockito.spy(androidGesturesManager.getMultiFingerTapGestureDetector());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class MultiFingerTapGestureDetectorTest
     map.clear();
     map.put(new PointerDistancePair(0, 1), new MultiFingerDistancesObject(
       prevX, prevY,
-      currX + Constants.DEFAULT_MULTI_TAP_MOVEMENT_THRESHOLD + 0.5f, currY
+      currX + gestureDetector.getMultiFingerTapMovementThreshold() + 0.5f, currY
     ));
     assertTrue(gestureDetector.exceededMovementThreshold(map));
   }

--- a/library/src/test/java/com/mapbox/android/gestures/RotateGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/RotateGestureDetectorTest.java
@@ -16,7 +16,7 @@ public class RotateGestureDetectorTest extends
 
   @Override
   RotateGestureDetector getDetectorObject() {
-    return spy(new RotateGestureDetector(context, androidGesturesManager));
+    return spy(androidGesturesManager.getRotateGestureDetector());
   }
 
   @Test

--- a/library/src/test/java/com/mapbox/android/gestures/ShoveGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/ShoveGestureDetectorTest.java
@@ -15,7 +15,7 @@ public class ShoveGestureDetectorTest extends
 
   @Override
   ShoveGestureDetector getDetectorObject() {
-    return spy(new ShoveGestureDetector(context, androidGesturesManager));
+    return spy(androidGesturesManager.getShoveGestureDetector());
   }
 
   @Test
@@ -26,12 +26,12 @@ public class ShoveGestureDetectorTest extends
     doReturn(true).when(gestureDetector).isAngleAcceptable();
 
     // threshold not met
-    doReturn(Constants.DEFAULT_SHOVE_PIXEL_THRESHOLD / 2)
+    doReturn(gestureDetector.getPixelDeltaThreshold() / 2)
       .when(gestureDetector).getDeltaPixelsSinceLast();
     gestureDetector.analyzeMovement();
 
     // threshold met, starting
-    doReturn(Constants.DEFAULT_SHOVE_PIXEL_THRESHOLD * 2)
+    doReturn(gestureDetector.getPixelDeltaThreshold() * 2)
       .when(gestureDetector).getDeltaPixelsSinceLast();
     gestureDetector.analyzeMovement();
 
@@ -41,7 +41,7 @@ public class ShoveGestureDetectorTest extends
       gestureDetector.deltaPixelSinceLast, gestureDetector.deltaPixelsSinceStart);
 
     // new event, executing onShove() even though below threshold because already started
-    doReturn(Constants.DEFAULT_SHOVE_PIXEL_THRESHOLD / 2)
+    doReturn(gestureDetector.getPixelDeltaThreshold() / 2)
       .when(gestureDetector).getDeltaPixelsSinceLast();
     gestureDetector.analyzeMovement();
     //still 1 invocation because parameters changed, but technically 2
@@ -68,7 +68,7 @@ public class ShoveGestureDetectorTest extends
     gestureDetector.analyzeMovement();
 
     // threshold met again, starting
-    doReturn(Constants.DEFAULT_SHOVE_PIXEL_THRESHOLD * 2)
+    doReturn(gestureDetector.getPixelDeltaThreshold() * 2)
       .when(gestureDetector).getDeltaPixelsSinceLast();
     gestureDetector.analyzeMovement();
 

--- a/library/src/test/java/com/mapbox/android/gestures/StandardGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/StandardGestureDetectorTest.java
@@ -11,7 +11,7 @@ public class StandardGestureDetectorTest extends
 
   @Override
   StandardGestureDetector getDetectorObject() {
-    return new StandardGestureDetector(context, androidGesturesManager);
+    return androidGesturesManager.getStandardGestureDetector();
   }
 
   @Test

--- a/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
@@ -14,7 +14,7 @@ public class StandardScaleGestureDetectorTest extends
 
   @Override
   StandardScaleGestureDetector getDetectorObject() {
-    return spy(new StandardScaleGestureDetector(context, androidGesturesManager));
+    return spy(androidGesturesManager.getStandardScaleGestureDetector());
   }
 
   @Test
@@ -40,8 +40,10 @@ public class StandardScaleGestureDetectorTest extends
     //interrupt
     gestureDetector.interrupt();
 
+    float threshold = gestureDetector.getSpanSinceStartThreshold();
+
     // no threshold, starting immediately
-    gestureDetector.setSpanSinceStartThreshold(0);
+    gestureDetector.setSpanSinceStartThreshold(0f);
     gestureDetector.startSpan = 0;
     gestureDetector.innerOnScaleBegin(gestureDetector.getUnderlyingScaleGestureDetector());
 
@@ -67,7 +69,7 @@ public class StandardScaleGestureDetectorTest extends
     gestureDetector.innerOnScaleEnd(gestureDetector.getUnderlyingScaleGestureDetector());
 
     // threshold not met
-    gestureDetector.setSpanSinceStartThreshold(gestureDetector.getDefaultSpanSinceStartThreshold());
+    gestureDetector.setSpanSinceStartThreshold(threshold);
     gestureDetector.startSpan = gestureDetector.getSpanSinceStartThreshold() / 2;
     gestureDetector.innerOnScaleBegin(gestureDetector.getUnderlyingScaleGestureDetector());
     gestureDetector.innerOnScale(gestureDetector.getUnderlyingScaleGestureDetector());


### PR DESCRIPTION
Closes #14.
This PR removes default threshold values getters and makes constant fields public to compliment for that.
Also, adds an option to initialize without default threshold values.