### PR TITLE
Decrease minimum span required to register scale gesture

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,8 @@ android {
 
 dependencies {
     implementation dependenciesList.supportAppcompatV7
+    implementation dependenciesList.timber
+
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockito
     testImplementation dependenciesList.robolectric

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.mapbox.android.gestures.testapp">
 
     <application
+        android:name=".MyApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/mapbox/android/gestures/testapp/MyApplication.java
+++ b/app/src/main/java/com/mapbox/android/gestures/testapp/MyApplication.java
@@ -1,0 +1,17 @@
+package com.mapbox.android.gestures.testapp;
+
+import android.app.Application;
+
+import timber.log.Timber;
+
+public class MyApplication extends Application {
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+
+    if (BuildConfig.DEBUG) {
+      Timber.plant(new Timber.DebugTree());
+    }
+  }
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
     version = [
             supportLibVersion: '25.4.0',
-            timber           : '4.6.1',
+            timber           : '4.5.1',
             junit            : '4.12',
             mockito          : '2.13.0',
             robolectric      : '3.7',

--- a/library/src/main/java/com/mapbox/android/gestures/Constants.java
+++ b/library/src/main/java/com/mapbox/android/gestures/Constants.java
@@ -16,4 +16,9 @@ public final class Constants {
    * Default time within which pointers need to leave the screen to register tap gesture.
    */
   public static final long DEFAULT_MULTI_TAP_TIME_THRESHOLD = 150L;
+
+
+  /*Private constants*/
+  static final String internal_scaleGestureDetectorMinSpanField = "mMinSpan";
+  static final String internal_scaleGestureDetectorSpanSlopField = "mSpanSlop";
 }

--- a/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
@@ -1,13 +1,16 @@
 package com.mapbox.android.gestures;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.annotation.DimenRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.VelocityTracker;
+import android.view.ViewConfiguration;
 
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -58,6 +61,36 @@ public class StandardScaleGestureDetector extends
     };
 
     scaleGestureDetector = new ScaleGestureDetector(context, innerListener);
+
+    try {
+      modifyInternalMinSpanValues();
+    } catch (NoSuchFieldException e) {
+      // ignore
+    } catch (IllegalAccessException e) {
+      // ignore
+    }
+  }
+
+  /**
+   * Workaround to allow scaling when pointers are close to each other.
+   * References https://github.com/mapbox/mapbox-gestures-android/issues/15
+   * and https://issuetracker.google.com/issues/37131665.
+   */
+  void modifyInternalMinSpanValues() throws NoSuchFieldException, IllegalAccessException {
+    final Field minSpanField = scaleGestureDetector.getClass().getDeclaredField(Constants.internal_scaleGestureDetectorMinSpanField);
+    minSpanField.setAccessible(true);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      minSpanField.set(
+        scaleGestureDetector, (int) context.getResources().getDimension(R.dimen.mapbox_internalScaleMinSpan24));
+    } else {
+      minSpanField.set(
+        scaleGestureDetector, (int) context.getResources().getDimension(R.dimen.mapbox_internalScaleMinSpan23));
+    }
+
+    final Field spanSlopField =
+      scaleGestureDetector.getClass().getDeclaredField(Constants.internal_scaleGestureDetectorSpanSlopField);
+    spanSlopField.setAccessible(true);
+    spanSlopField.set(scaleGestureDetector, ViewConfiguration.get(context).getScaledTouchSlop());
   }
 
   boolean innerOnScale(ScaleGestureDetector detector) {

--- a/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
@@ -64,9 +64,9 @@ public class StandardScaleGestureDetector extends
 
     try {
       modifyInternalMinSpanValues();
-    } catch (NoSuchFieldException e) {
+    } catch (NoSuchFieldException ex) {
       // ignore
-    } catch (IllegalAccessException e) {
+    } catch (IllegalAccessException ex) {
       // ignore
     }
   }
@@ -77,7 +77,8 @@ public class StandardScaleGestureDetector extends
    * and https://issuetracker.google.com/issues/37131665.
    */
   void modifyInternalMinSpanValues() throws NoSuchFieldException, IllegalAccessException {
-    final Field minSpanField = scaleGestureDetector.getClass().getDeclaredField(Constants.internal_scaleGestureDetectorMinSpanField);
+    final Field minSpanField =
+      scaleGestureDetector.getClass().getDeclaredField(Constants.internal_scaleGestureDetectorMinSpanField);
     minSpanField.setAccessible(true);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       minSpanField.set(

--- a/library/src/main/java/com/mapbox/android/gestures/Utils.java
+++ b/library/src/main/java/com/mapbox/android/gestures/Utils.java
@@ -1,7 +1,11 @@
 package com.mapbox.android.gestures;
 
+import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.PointF;
 import android.support.annotation.NonNull;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.MotionEvent;
 
 public class Utils {
@@ -55,5 +59,37 @@ public class Utils {
       return event.getY(pointerIndex) + offset;
     }
     return 0.0f;
+  }
+
+  /**
+   * Converts DIP to PX.
+   *
+   * @param dp initial value
+   * @return converted value
+   */
+  public static float dpToPx(float dp) {
+    return dp * Resources.getSystem().getDisplayMetrics().density;
+  }
+
+  /**
+   * Converts PX to DIP.
+   *
+   * @param px initial value
+   * @return converted value
+   */
+  public static float pxToDp(float px) {
+    return px / Resources.getSystem().getDisplayMetrics().density;
+  }
+
+  /**
+   * Converts PX to MM (millimeters).
+   *
+   * @param px      initial value
+   * @param context context
+   * @return converted value
+   */
+  public static float pxToMm(final float px, final Context context) {
+    final DisplayMetrics dm = context.getResources().getDisplayMetrics();
+    return px / TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_MM, 1, dm);
   }
 }

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -13,4 +13,10 @@
 
     <!--Default pointer's position change required to abort tap gesture-->
     <dimen name="mapbox_defaultMultiTapMovementThreshold">5dp</dimen>
+
+    <!--Minimum span required to process scale gesture for API >= 24-->
+    <dimen name="mapbox_internalScaleMinSpan24">6mm</dimen>
+
+    <!--Minimum span required to process scale gesture for API < 24-->
+    <dimen name="mapbox_internalScaleMinSpan23">10mm</dimen>
 </resources>

--- a/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
+++ b/library/src/test/java/com/mapbox/android/gestures/StandardScaleGestureDetectorTest.java
@@ -81,4 +81,10 @@ public class StandardScaleGestureDetectorTest extends
     verify(listener, times(3)).onScaleEnd(
       gestureDetector, gestureDetector.velocityX, gestureDetector.velocityY);
   }
+
+  @Test
+  public void internalMinSpanSetterTest() throws Exception {
+    // future-proofing against API changes
+    gestureDetector.modifyInternalMinSpanValues();
+  }
 }


### PR DESCRIPTION
Closes #15.

After testing issue referenced in https://issuetracker.google.com/issues/37131665 I noticed that's it's due to a strange change in the conversion of PX to DIP to MM values between API versions. Because of this, I think the better idea is to adjust span values themselves and still rely on the rest of the upstream implementation for the time being.

This PR decreases minimum span required between pointers to register scale gesture to bare minimum, to cut out extreme edge cases. However, it can still introduce some uncontrolled scale changes when pointers are extremely close.
Additionally, this PR also decreases `quickzoom` deadzone by half.