### PR TITLE
Update Readme with correct dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ repositories {
 ```java
 // In the app build.gradle file
 dependencies {
-    implementation 'com.mapbox.mapboxsdk:mapbox-gestures-android:0.3.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-gestures:0.3.0'
 }
 ```
 


### PR DESCRIPTION
Copying @Kahtaf 's work in https://github.com/mapbox/mapbox-gestures-android/pull/51 so that CircleCI tests run for this repo.  Thanks again for finding the error, @Kahtaf! 🔬 