### PR TITLE
Remove obsolete string values

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Mapbox Gestures Android</string>
-</resources>


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/14078#issuecomment-471989706.

Hopefully fixes:
> ../../src/main/res/values/strings.xml:2: Overriding @string/app_name which is marked as private in com.mapbox.mapboxsdk:mapbox-android-sdk. If deliberate, use tools:override="true", otherwise pick a different name.