### PR TITLE
Adjust scale gesture's required pointer count based on type

### DIFF
--- a/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
@@ -146,7 +146,11 @@ public class StandardScaleGestureDetector extends
 
   @Override
   protected int getRequiredPointersCount() {
-    return 1;
+    if (isInProgress()) {
+      return quickScale ? 1 : 2;
+    } else {
+      return 1;
+    }
   }
 
   @Override


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/14775.

This ensures to finish the pinch gesture when one before the last pointer is lifted, which prevents accumulating unnecessary velocity events.