### PR TITLE
Calculate focal point for every motion event, not only MOVE

### DIFF
--- a/app/src/androidTest/java/com/mapbox/android/gestures/GesturesUiTestUtils.kt
+++ b/app/src/androidTest/java/com/mapbox/android/gestures/GesturesUiTestUtils.kt
@@ -76,6 +76,28 @@ object GesturesUiTestUtils {
     }
   }
 
+  fun twoTap(span: Float, center: PointF? = null, withMove: Boolean = false, moveChange: Float = 200f, duration: Long = DEFAULT_GESTURE_DURATION): ViewAction {
+    return object : ViewAction {
+      override fun getConstraints(): Matcher<View> {
+        return ViewMatchers.isEnabled()
+      }
+
+      override fun getDescription(): String = "TwoTap, span: $span"
+
+      override fun perform(uiController: UiController, view: View) {
+        var middlePosition = center
+        if (middlePosition == null) {
+          middlePosition = getCenterPointF(view)
+        }
+
+        val point1 = PointF(middlePosition.x - span / 2f, middlePosition.y)
+        val point2 = PointF(middlePosition.x + span / 2f, middlePosition.y)
+
+        performTwoTap(uiController, point1, point2, withMove, moveChange, duration)
+      }
+    }
+  }
+
   private fun getCenterPointF(view: View): PointF {
     val locationOnScreen = IntArray(2)
     view.getLocationOnScreen(locationOnScreen)
@@ -437,6 +459,131 @@ object GesturesUiTestUtils {
       injectMotionEventToUiController(uiController, event)
     } catch (ex: InjectEventSecurityException) {
       throw RuntimeException("Could not perform quick scale", ex)
+    }
+  }
+
+  private fun performTwoTap(
+    uiController: UiController,
+    point1: PointF,
+    point2: PointF,
+    withMove: Boolean,
+    moveChange: Float,
+    duration: Long
+  ) {
+    val eventMinInterval: Long = 10
+    val startTime = SystemClock.uptimeMillis()
+    var eventTime = startTime
+    var event: MotionEvent
+    var eventX1: Float = point1.x
+    var eventY1: Float = point1.y
+    var eventX2: Float = point2.x
+    var eventY2: Float = point2.y
+
+    // Specify the property for the two touch points
+    val properties = arrayOfNulls<MotionEvent.PointerProperties>(2)
+    val pp1 = MotionEvent.PointerProperties()
+    pp1.id = 0
+    pp1.toolType = MotionEvent.TOOL_TYPE_FINGER
+    val pp2 = MotionEvent.PointerProperties()
+    pp2.id = 1
+    pp2.toolType = MotionEvent.TOOL_TYPE_FINGER
+
+    properties[0] = pp1
+    properties[1] = pp2
+
+    // Specify the coordinations of the two touch points
+    // NOTE: you MUST set the pressure and size value, or it doesn't work
+    val pointerCoords = arrayOfNulls<MotionEvent.PointerCoords>(2)
+    val pc1 = MotionEvent.PointerCoords()
+    pc1.x = eventX1
+    pc1.y = eventY1
+    pc1.pressure = 1f
+    pc1.size = 1f
+    val pc2 = MotionEvent.PointerCoords()
+    pc2.x = eventX2
+    pc2.y = eventY2
+    pc2.pressure = 1f
+    pc2.size = 1f
+    pointerCoords[0] = pc1
+    pointerCoords[1] = pc2
+
+    /*
+     * Events sequence of zoom gesture:
+     *
+     * 1. Send ACTION_DOWN event of one start point
+     * 2. Send ACTION_POINTER_DOWN of two start points
+     * 3. Send ACTION_MOVE of two middle points (optional)
+     * 4. Send ACTION_POINTER_UP of two end points
+     * 5. Send ACTION_UP of one end point
+     */
+
+    try {
+      // Step 1
+      event = MotionEvent.obtain(startTime, eventTime,
+        MotionEvent.ACTION_DOWN, 1, properties,
+        pointerCoords, 0, 0, 1f, 1f, 0, 0, 0, 0)
+      injectMotionEventToUiController(uiController, event)
+
+      // Step 2
+      event = MotionEvent.obtain(startTime, eventTime,
+        MotionEvent.ACTION_POINTER_DOWN + (pp2.id shl MotionEvent.ACTION_POINTER_INDEX_SHIFT), 2,
+        properties, pointerCoords, 0, 0, 1f, 1f, 0, 0, 0, 0)
+      injectMotionEventToUiController(uiController, event)
+
+      if (withMove) {
+        // Step 3
+        val moveEventNumber = duration / eventMinInterval
+
+        val step = moveChange / moveEventNumber
+
+        for (i in 0 until moveEventNumber) {
+          // Update the move events
+          eventTime += eventMinInterval
+          eventX1 += step
+          eventY1 += step
+          eventX2 += step
+          eventY2 += step
+
+          pc1.x = eventX1
+          pc1.y = eventY1
+          pc2.x = eventX2
+          pc2.y = eventY2
+
+          pointerCoords[0] = pc1
+          pointerCoords[1] = pc2
+
+          event = MotionEvent.obtain(startTime, eventTime,
+            MotionEvent.ACTION_MOVE, 2, properties,
+            pointerCoords, 0, 0, 1f, 1f, 0, 0, 0, 0)
+          injectMotionEventToUiController(uiController, event)
+        }
+
+        // Step 5
+        pc1.x = point1.x + step * moveEventNumber
+        pc1.y = point1.y + step * moveEventNumber
+        pc2.x = point2.x + step * moveEventNumber
+        pc2.y = point2.y + step * moveEventNumber
+        pointerCoords[0] = pc1
+        pointerCoords[1] = pc2
+      } else {
+        // min tap interval
+        eventTime += 50
+      }
+
+      eventTime += eventMinInterval
+      event = MotionEvent.obtain(startTime, eventTime,
+        MotionEvent.ACTION_POINTER_UP + (pp2.id shl MotionEvent.ACTION_POINTER_INDEX_SHIFT), 2, properties,
+        pointerCoords, 0, 0, 1f, 1f, 0, 0, 0, 0)
+      injectMotionEventToUiController(uiController, event)
+
+      // Step 6
+      eventTime += eventMinInterval
+      event = MotionEvent.obtain(startTime, eventTime,
+        MotionEvent.ACTION_UP, 1, properties,
+        pointerCoords, 0, 0, 1f, 1f, 0, 0, 0, 0)
+      injectMotionEventToUiController(uiController, event)
+    } catch (ex: InjectEventSecurityException) {
+      throw RuntimeException("Could not perform pinch", ex)
     }
   }
 

--- a/app/src/androidTest/java/com/mapbox/android/gestures/MultiFingerTapGestureDetectorTest.kt
+++ b/app/src/androidTest/java/com/mapbox/android/gestures/MultiFingerTapGestureDetectorTest.kt
@@ -1,0 +1,48 @@
+package com.mapbox.android.gestures
+
+import GesturesUiTestUtils.DEFAULT_GESTURE_DURATION
+import GesturesUiTestUtils.twoTap
+import android.support.test.espresso.Espresso
+import android.support.test.espresso.matcher.ViewMatchers
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.mapbox.android.gestures.testapp.R
+import com.mapbox.android.gestures.testapp.TestActivity
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class MultiFingerTapGestureDetectorTest {
+
+  @Rule
+  @JvmField
+  val activityTestRule = ActivityTestRule(TestActivity::class.java)
+
+  private lateinit var gesturesManager: AndroidGesturesManager
+
+  @Before
+  fun setup() {
+    gesturesManager = activityTestRule.activity.gesturesManager
+  }
+
+  @Test
+  fun noMove_focalPoint_invalidated() {
+    val latch = CountDownLatch(1)
+    gesturesManager.setMultiFingerTapGestureListener { detector, pointersCount ->
+      Assert.assertEquals(2, pointersCount)
+      Assert.assertEquals(Utils.determineFocalPoint(detector.currentEvent), detector.focalPoint)
+      latch.countDown()
+      true
+    }
+    Espresso.onView(ViewMatchers.withId(R.id.content)).perform(twoTap(300f))
+
+    if (!latch.await(DEFAULT_GESTURE_DURATION, TimeUnit.MILLISECONDS)) {
+      Assert.fail("two-tap was not called")
+    }
+  }
+}

--- a/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
+++ b/library/src/main/java/com/mapbox/android/gestures/MultiFingerGesture.java
@@ -89,6 +89,8 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
       updatePointerList(motionEvent);
     }
 
+    focalPoint = Utils.determineFocalPoint(motionEvent);
+
     if (isMissingEvents) {
       Log.w("MultiFingerGesture", "Some MotionEvents were not passed to the library "
         + "or events from different view trees are merged.");
@@ -98,7 +100,6 @@ public abstract class MultiFingerGesture<L> extends BaseGesture<L> {
         if (pointerIdList.size() >= getRequiredPointersCount() && checkPressure()) {
           calculateDistances();
           if (!isSloppyGesture()) {
-            focalPoint = Utils.determineFocalPoint(motionEvent);
             return analyzeMovement();
           }
         }


### PR DESCRIPTION
In a situation where a multi-finger gesture is executed without any pointer movement, the cached focal point is delivered instead of the current one. This has been discovered using the multi-finger tap detector.