### PR TITLE
Run tag release jobs on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,10 @@ workflows:
   default:
     jobs:
       - build
-      - release
+      - release:
+          filters:
+            tags:
+              only: /v.*/
 jobs:
   build:
     working_directory: ~/code


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gestures-android/pull/72 follow up. [Per docs](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag), a tag filter has to be specified to start a job.