### PR TITLE
Fixup stable Bintray publication

### DIFF
--- a/gradle/gradle-bintray.gradle
+++ b/gradle/gradle-bintray.gradle
@@ -46,7 +46,7 @@ publishing {
 bintray {
     user = mapboxBintrayUser
     key = mapboxBintrayApiKey
-    publications = ['MapboxGesturesPublication']
+    publications('MapboxGesturesPublication')
     pkg {
         repo = project.ext.mapboxBintrayRepoName
         name = project.ext.mapboxArtifactId
@@ -83,9 +83,18 @@ artifactory {
     }
 }
 
+task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.sourceFiles
+    classpath = files(android.bootClasspath)
+    failOnError = false
+}
 
-tasks.withType(Javadoc) {
-    options.addStringOption('encoding', 'UTF-8')
-    options.addStringOption('docencoding', 'UTF-8')
-    options.addStringOption('charset', 'UTF-8')
+task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    classifier = 'javadoc'
+    from androidJavadocs.destinationDir
+}
+
+task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.sourceFiles
 }


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gestures-android/pull/72 follow up.

Stable builds throw:
```
* What went wrong:
Execution failed for task ':library:publishMapboxGesturesPublicationPublicationToMavenLocal'.
> Failed to publish publication 'MapboxGesturesPublication' to repository 'mavenLocal'
   > Invalid publication 'MapboxGesturesPublication': version cannot be empty.
```

I'm hoping it's an incorrect publication bracket and missing tasks.