### PR TITLE
Remove Koltin extensions from the library module

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: "../gradle/dependencies.gradle"
 
 android {


### PR DESCRIPTION
It's not utilized in the `:library` module.