### PR TITLE
Manually mark double tap as finished on ACTION_UP if the quick-zoom wasn't started

### DIFF
--- a/app/src/androidTest/java/com/mapbox/android/gestures/ScaleGestureDetectorTest.kt
+++ b/app/src/androidTest/java/com/mapbox/android/gestures/ScaleGestureDetectorTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.android.gestures
 
 import GesturesUiTestUtils.DEFAULT_GESTURE_DURATION
+import GesturesUiTestUtils.move
 import GesturesUiTestUtils.pinch
 import GesturesUiTestUtils.quickScale
 import android.os.Build
@@ -11,7 +12,7 @@ import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import com.mapbox.android.gestures.testapp.R
 import com.mapbox.android.gestures.testapp.TestActivity
-import junit.framework.Assert
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -596,4 +597,25 @@ class ScaleGestureDetectorTest {
     onView(withId(R.id.content)).perform(quickScale(delta))
   }
 
+  @Test
+  fun doubleTap_move_doNotQuickZoom() {
+    gesturesManager.setStandardScaleGestureListener(object : StandardScaleGestureDetector.StandardOnScaleGestureListener {
+      override fun onScaleBegin(detector: StandardScaleGestureDetector): Boolean {
+        Assert.fail("scale detector should not be called")
+        return true
+      }
+
+      override fun onScale(detector: StandardScaleGestureDetector): Boolean {
+        Assert.fail("scale detector should not be called")
+        return true
+      }
+
+      override fun onScaleEnd(detector: StandardScaleGestureDetector, velocityX: Float, velocityY: Float) {
+        Assert.fail("scale detector should not be called")
+      }
+    })
+
+    onView(withId(R.id.content)).perform(quickScale(gesturesManager.standardScaleGestureDetector.spanSinceStartThreshold / 2, withVelocity = false, duration = 50L))
+    onView(withId(R.id.content)).perform(move(300f, 300f, withVelocity = false))
+  }
 }

--- a/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
+++ b/library/src/main/java/com/mapbox/android/gestures/StandardScaleGestureDetector.java
@@ -139,17 +139,23 @@ public class StandardScaleGestureDetector extends
   @Override
   protected boolean analyzeEvent(MotionEvent motionEvent) {
     int action = motionEvent.getActionMasked();
-    if (action == MotionEvent.ACTION_POINTER_DOWN || action == MotionEvent.ACTION_CANCEL) {
-      if (quickScale) {
+
+    if (quickScale) {
+      if (action == MotionEvent.ACTION_POINTER_DOWN || action == MotionEvent.ACTION_CANCEL) {
         if (isInProgress()) {
           interrupt();
-        } else if (quickScale) {
+        } else {
           // since the double tap has been registered and canceled but the gesture wasn't started,
           // we need to mark it manually
           quickScale = false;
         }
+      } else if (!isInProgress() && action == MotionEvent.ACTION_UP) {
+        // if double tap has been registered but the threshold was not met and gesture is not in progress,
+        // we need to manually mark the finish of a double tap
+        quickScale = false;
       }
     }
+
     boolean handled = super.analyzeEvent(motionEvent);
     return handled | innerGestureDetector.onTouchEvent(motionEvent);
   }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/15409.

When a simple double-tap was executed, without quick-zoom, the gesture wasn't properly marked as finished, therefore the next move gesture was considered a continuation of a quick-zoom.