### PR TITLE
Revert kotlin to the version compatible with bintray plugin.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,11 @@ ext {
             robolectric      : '4.8.1',
             testRunner       : '1.1.3',
             espresso         : '3.4.0',
-            kotlin           : '1.5.31',
+            kotlin           : '1.4.21',
+// latest kotlin version compatible with bintray plugin 1.8.5, issue https://github.com/bintray/gradle-bintray-plugin/issues/292
+//       > Failed to publish publication 'MapboxGesturesPublication' to repository 'mavenLocal'
+//       > Invalid publication 'MapboxGesturesPublication': multiple artifacts with the identical extension and classifier ('aar', 'null').
+
             appCompat        : '1.3.0',
             core             : '1.7.0', // last version compatible with kotlin 1.5.31
             annotation       : '1.1.0'


### PR DESCRIPTION
Publication of 0.8.0 [failed](https://app.circleci.com/pipelines/github/mapbox/mapbox-gestures-android/13/workflows/ad3ff65a-c241-444d-85c9-117d31308522/jobs/545) due to 
```
> Failed to publish publication 'MapboxGesturesPublication' to repository 'mavenLocal'
   > Invalid publication 'MapboxGesturesPublication': multiple artifacts with the identical extension and classifier ('aar', 'null').
```
[Issue](https://github.com/bintray/gradle-bintray-plugin/issues/292) was raised long ago. 

Reverted kotlin for now to publish the dependency, but we should migrate from bintray plugin I suppose.  