### PR TITLE
Upgrade sdk registry plugin to v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the Mapbox Gestures for Android
 
+## 0.9.1 - November 27, 2023
+Minor release with internal fixes for publishing library
+
 ## 0.9.0 - November 24, 2023
 #### Breaking changes
  - Increase minimum supported Android SDK version to 19 (KITKAT)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
             checkstyle    : '8.4',
             gradle        : '7.0.4',
             androidPublish: '3.6.3',
-            sdkRegistry   : '0.8.0',
+            sdkRegistry   : '1.2.1',
     ]
 
     dependenciesList = [


### PR DESCRIPTION
It turns out that publishing the 0.9.0 release [failed due to](https://app.circleci.com/pipelines/github/mapbox/mapbox-gestures-android/42/workflows/f2e9a40a-c1f5-4cec-88ce-40ef35bfb9f4/jobs/597?invite=true#step-105-32161_36):
```
******SDKRegistryPublish for library
Cloning api-downloads repo with https...
Cloning into '/root/code/library/build/******SDKRegistryConfigs/api-downloads'...
remote: Support for password authentication was removed on August 13, 2021.
remote: Please see https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
fatal: Authentication failed for 'https://github.com/******/api-downloads.git/'
```

This PR upgrades to the latest sdk-registry plugin version available 1.2.1.