### PR TITLE
Set Github token and git username/mail before publishing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -68,6 +68,9 @@ jobs:
       - deploy:
           name: Publish to the SDK registry
           command: |
+            git config --global user.email "MapboxCI@users.noreply.github.com"
+            git config --global user.name "MapboxCI"
+            export GITHUB_TOKEN=$(./mbx-ci github writer private token)
             if [[ $CIRCLE_BRANCH == master ]] || [[ $CIRCLE_TAG == v* ]]; then
               make sdkRegistryUpload
             fi


### PR DESCRIPTION
We were missing the gihtub token to be able to clone `api-downloads` repo and also the git email and name.